### PR TITLE
fixe Marr-Hildreth Hash kernel error

### DIFF
--- a/imgproc/color.go
+++ b/imgproc/color.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"image"
 	"image/color"
-	"math"
 )
 
 // ErrImageIsNil ...
@@ -17,11 +16,9 @@ func Grayscale(img image.Image) (*image.Gray, error) {
 	}
 	bounds := img.Bounds()
 	gray := image.NewGray(bounds)
-	for x := bounds.Min.X; x < bounds.Max.X; x++ {
-		for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
-			r, g, b, _ := img.At(x, y).RGBA()
-			lum := uint8(math.Round(0.299*float64(r/0x101) + 0.587*float64(g/0x101) + 0.114*float64(b/0x101)))
-			gray.Set(x, y, color.Gray{lum})
+	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
+		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
+			gray.Set(x, y, img.At(x, y))
 		}
 	}
 	return gray, nil

--- a/imgproc/common.go
+++ b/imgproc/common.go
@@ -64,3 +64,27 @@ func getSize(img image.Image) (int, int) {
 func cvRound(value float64) int {
 	return int(math.Round(value))
 }
+
+// Normalize normalize images to [0,1] range
+func Normalize(img [][]float32) {
+	var max, min float32
+	max = -1 << 30
+	min = 1 << 30
+	for _, list := range img {
+		for _, v := range list {
+			if v > max {
+				max = v
+			}
+			if v < min {
+				min = v
+			}
+		}
+	}
+
+	diff := max - min
+	for x, list := range img {
+		for y, v := range list {
+			(img)[x][y] = (v - min) / diff
+		}
+	}
+}

--- a/marrhildreth.go
+++ b/marrhildreth.go
@@ -128,7 +128,7 @@ func computeMarrHildrethKernel(alpha, level float64) [][]float32 {
 		for j := range kernel[i] {
 			xpos := ratio * float32(j-sigma)
 			a := float64(xpos*xpos + yposPow2)
-			kernel[i][j] = float32((2 - a) * math.Exp(a/2))
+			kernel[i][j] = float32((2 - a) * math.Exp(a/-2))
 		}
 	}
 	return kernel

--- a/marrhildreth.go
+++ b/marrhildreth.go
@@ -27,6 +27,8 @@ type MarrHildreth struct {
 	kernel int
 	// Gaussian kernel sigma parameter.
 	sigma float64
+
+	kernels [][]float32
 }
 
 // NewMarrHildreth creates a new MarrHildreth struct using default values.
@@ -44,7 +46,7 @@ func NewMarrHildreth() MarrHildreth {
 
 // NewMarrHildrethWithParams creates a new MarrHildreth struct using the supplied parameters.
 func NewMarrHildrethWithParams(scale, alpha float64, resizeWidth, resizeHeight uint, resizeType imgproc.ResizeType, kernelSize int, sigma float64) MarrHildreth {
-	return MarrHildreth{
+	mh := MarrHildreth{
 		scale:  scale,
 		alpha:  alpha,
 		width:  resizeWidth,
@@ -53,6 +55,8 @@ func NewMarrHildrethWithParams(scale, alpha float64, resizeWidth, resizeHeight u
 		kernel: kernelSize,
 		sigma:  sigma,
 	}
+	mh.kernels = computeMarrHildrethKernel(alpha, scale)
+	return mh
 }
 
 // Calculate returns a perceptual image hash.
@@ -62,8 +66,7 @@ func (mhh *MarrHildreth) Calculate(img image.Image) hashtype.Binary {
 	r := imgproc.Resize(mhh.width, mhh.height, b, mhh.interp)
 	eq := imgproc.EqualizeHist(r.(*image.Gray))
 	// Run a 2D marr hildereth filter over image
-	kernel := computeMarrHildrethKernel(mhh.alpha, mhh.scale)
-	f := imgproc.Filter2DGray(eq, kernel)
+	f := imgproc.Filter2DGray(eq, mhh.kernels)
 	blks := mhh.blocksSum(f)
 	return mhh.createHash(blks)
 }


### PR DESCRIPTION
Signed-off-by: Leslie Qi Wang <wqyuwss@gmail.com>

Based on https://github.com/aetilius/pHash/blob/master/src/pHash.cpp#L610, and https://web.fe.up.pt/~campilho/PDI/NOTES/EdgeDetection.pdf. Seems kernel should be `-1 * a/2` or `a/-2`. 

Thanks for the nice work. It is the only one having all image hashing algorithm!