### PR TITLE
feat: Wavelet Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can also call `h1.Distance(h2)` directly on any hash value.
 
 ## Perceptual Hash Algorithms
 
-The library supports 8 perceptual hashing algorithms ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
+The library supports 9 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
 
 Every constructor accepts functional options. Call with no arguments for defaults, or pass `With*` options to customize:
 
@@ -151,6 +151,21 @@ hash, err := ph.Calculate(img)
 |--------|---------|
 | `WithSize(w, h)` | 32, 32 |
 | `WithInterpolation(i)` | `BilinearExact` |
+
+#### Wavelet Hash (wHash)
+
+Uses a multi-level Haar discrete wavelet transform to produce a 64-bit binary hash. The image is resized to `(width * 2^level) x (height * 2^level)`, converted to grayscale, and decomposed via the Haar DWT. The low-frequency (LL) subband coefficients are thresholded against their median. See [Wavelet image hash](https://fullstackml.com/wavelet-image-hash-in-python-3504571f3b08) for more information.
+
+```go
+wh, err := imghash.NewWHash()
+hash, err := wh.Calculate(img)
+```
+
+| Option | Default |
+|--------|---------|
+| `WithSize(w, h)` | 8, 8 |
+| `WithInterpolation(i)` | `Bilinear` |
+| `WithLevel(l)` | 3 |
 
 #### Color Moments Hash
 

--- a/imghash.go
+++ b/imghash.go
@@ -11,7 +11,7 @@ import (
 // Hasher computes a perceptual hash from an image.
 // It is implemented by all hash algorithms in this package:
 // Average, Difference, PHash, Median, BlockMean, MarrHildreth,
-// RadialVariance, and ColorMoment.
+// RadialVariance, ColorMoment, and WHash.
 type Hasher interface {
 	Calculate(image.Image) (hashtype.Hash, error)
 }
@@ -53,4 +53,6 @@ var (
 	ErrInvalidAlpha = errors.New("imghash: alpha must be greater than zero")
 	// ErrInvalidSigma is returned when sigma is negative.
 	ErrInvalidSigma = errors.New("imghash: sigma must not be negative")
+	// ErrInvalidLevel is returned when the wavelet decomposition level is not positive.
+	ErrInvalidLevel = errors.New("imghash: level must be greater than zero")
 )

--- a/internal/imgproc/transform.go
+++ b/internal/imgproc/transform.go
@@ -58,6 +58,52 @@ func matf64Tof32(mat [][]float64) [][]float32 {
 	return res
 }
 
+// HaarDWT2D applies a multi-level 2-D Haar discrete wavelet transform
+// in-place on the top-left region of mat. After `levels` iterations the
+// top-left (rows/2^levels)×(cols/2^levels) block holds the LL coefficients.
+func HaarDWT2D(mat [][]float32, levels int) {
+	rows := len(mat)
+	if rows == 0 {
+		return
+	}
+	cols := len(mat[0])
+	for l := 0; l < levels; l++ {
+		h := rows >> uint(l)
+		w := cols >> uint(l)
+		if h < 2 || w < 2 {
+			break
+		}
+		haarRows(mat, h, w)
+		haarCols(mat, h, w)
+	}
+}
+
+func haarRows(mat [][]float32, rows, cols int) {
+	half := cols / 2
+	tmp := make([]float32, cols)
+	for r := 0; r < rows; r++ {
+		for c := 0; c < half; c++ {
+			tmp[c] = (mat[r][2*c] + mat[r][2*c+1]) / 2
+			tmp[half+c] = (mat[r][2*c] - mat[r][2*c+1]) / 2
+		}
+		copy(mat[r][:cols], tmp)
+	}
+}
+
+func haarCols(mat [][]float32, rows, cols int) {
+	half := rows / 2
+	tmp := make([]float32, rows)
+	for c := 0; c < cols; c++ {
+		for r := 0; r < half; r++ {
+			tmp[r] = (mat[2*r][c] + mat[2*r+1][c]) / 2
+			tmp[half+r] = (mat[2*r][c] - mat[2*r+1][c]) / 2
+		}
+		for r := 0; r < rows; r++ {
+			mat[r][c] = tmp[r]
+		}
+	}
+}
+
 func transpose(mat [][]float64) [][]float64 {
 	height := len(mat)
 	width := len(mat[0])

--- a/internal/imgproc/transform_test.go
+++ b/internal/imgproc/transform_test.go
@@ -70,3 +70,45 @@ func TestMatf64Tof32(t *testing.T) {
 		t.Errorf("conversion incorrect")
 	}
 }
+
+func TestHaarDWT2D_oneLevel(t *testing.T) {
+	mat := [][]float32{
+		{1, 2, 3, 4},
+		{5, 6, 7, 8},
+		{9, 10, 11, 12},
+		{13, 14, 15, 16},
+	}
+	HaarDWT2D(mat, 1)
+	// LL quadrant (top-left 2x2): averages of 2x2 blocks
+	wantLL := [][]float32{
+		{3.5, 5.5},
+		{11.5, 13.5},
+	}
+	for r := 0; r < 2; r++ {
+		for c := 0; c < 2; c++ {
+			if math.Abs(float64(mat[r][c]-wantLL[r][c])) > 1e-5 {
+				t.Errorf("LL[%d][%d] = %v, want %v", r, c, mat[r][c], wantLL[r][c])
+			}
+		}
+	}
+}
+
+func TestHaarDWT2D_twoLevels(t *testing.T) {
+	mat := [][]float32{
+		{1, 2, 3, 4},
+		{5, 6, 7, 8},
+		{9, 10, 11, 12},
+		{13, 14, 15, 16},
+	}
+	HaarDWT2D(mat, 2)
+	// After 2 levels the top-left 1x1 is the global average
+	globalAvg := float32(8.5)
+	if math.Abs(float64(mat[0][0]-globalAvg)) > 1e-5 {
+		t.Errorf("LL after 2 levels = %v, want %v", mat[0][0], globalAvg)
+	}
+}
+
+func TestHaarDWT2D_empty(t *testing.T) {
+	HaarDWT2D(nil, 1)
+	HaarDWT2D([][]float32{}, 1)
+}

--- a/options.go
+++ b/options.go
@@ -27,6 +27,9 @@ type RadialVarianceOption interface{ applyRadialVariance(*RadialVariance) }
 // ColorMomentOption configures the ColorMoment hash algorithm.
 type ColorMomentOption interface{ applyColorMoment(*ColorMoment) }
 
+// WHashOption configures the WHash algorithm.
+type WHashOption interface{ applyWHash(*WHash) }
+
 // --- concrete option types ---
 
 type sizeOption struct{ width, height uint }
@@ -38,6 +41,7 @@ func (o sizeOption) applyPHash(p *PHash)               { p.width, p.height = o.w
 func (o sizeOption) applyBlockMean(b *BlockMean)       { b.rWidth, b.rHeight = o.width, o.height }
 func (o sizeOption) applyMarrHildreth(m *MarrHildreth) { m.width, m.height = o.width, o.height }
 func (o sizeOption) applyColorMoment(c *ColorMoment)   { c.width, c.height = o.width, o.height }
+func (o sizeOption) applyWHash(w *WHash)               { w.width, w.height = o.width, o.height }
 
 type interpolationOption struct{ interp Interpolation }
 
@@ -48,6 +52,7 @@ func (o interpolationOption) applyPHash(p *PHash)               { p.interp = o.i
 func (o interpolationOption) applyBlockMean(b *BlockMean)       { b.interp = o.interp }
 func (o interpolationOption) applyMarrHildreth(m *MarrHildreth) { m.interp = o.interp }
 func (o interpolationOption) applyColorMoment(c *ColorMoment)   { c.interp = o.interp }
+func (o interpolationOption) applyWHash(w *WHash)               { w.interp = o.interp }
 
 type kernelSizeOption struct{ size int }
 
@@ -80,16 +85,20 @@ type anglesOption struct{ angles int }
 
 func (o anglesOption) applyRadialVariance(r *RadialVariance) { r.angles = o.angles }
 
+type levelOption struct{ level int }
+
+func (o levelOption) applyWHash(w *WHash) { w.level = o.level }
+
 // --- public constructors ---
 
 // WithSize sets the resize dimensions used during hash computation.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, and ColorMoment.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, and WHash.
 func WithSize(width, height uint) sizeOption {
 	return sizeOption{width, height}
 }
 
 // WithInterpolation sets the resize interpolation method.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, and ColorMoment.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, and WHash.
 func WithInterpolation(interp Interpolation) interpolationOption {
 	return interpolationOption{interp}
 }
@@ -134,4 +143,10 @@ func WithAlpha(alpha float64) alphaOption {
 // Applies to RadialVariance.
 func WithAngles(angles int) anglesOption {
 	return anglesOption{angles}
+}
+
+// WithLevel sets the number of Haar wavelet decomposition levels.
+// Applies to WHash.
+func WithLevel(level int) levelOption {
+	return levelOption{level}
 }

--- a/options_typecheck_test.go
+++ b/options_typecheck_test.go
@@ -35,3 +35,7 @@ var _ ColorMomentOption = WithSize(0, 0)
 var _ ColorMomentOption = WithInterpolation(Bilinear)
 var _ ColorMomentOption = WithKernelSize(0)
 var _ ColorMomentOption = WithSigma(0)
+
+var _ WHashOption = WithSize(0, 0)
+var _ WHashOption = WithInterpolation(Bilinear)
+var _ WHashOption = WithLevel(0)

--- a/wavelet.go
+++ b/wavelet.go
@@ -1,0 +1,108 @@
+package imghash
+
+import (
+	"image"
+	"sort"
+
+	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/internal/imgproc"
+)
+
+// WHash is a perceptual hash based on the Haar wavelet transform.
+// It applies a multi-level 2-D discrete wavelet transform to the image
+// and thresholds the low-frequency (LL) coefficients against their median.
+//
+// See https://fullstackml.com/wavelet-image-hash-in-python-3504571f3b08 for more information.
+type WHash struct {
+	// Hash output width (columns in the LL subband).
+	width uint
+	// Hash output height (rows in the LL subband).
+	height uint
+	// Number of Haar DWT decomposition levels.
+	level int
+	// Resize interpolation method.
+	interp Interpolation
+}
+
+// NewWHash creates a new WHash with the given options.
+// Without options, sensible defaults are used (8×8 hash, 3 levels, Bilinear).
+func NewWHash(opts ...WHashOption) (WHash, error) {
+	w := WHash{
+		width:  8,
+		height: 8,
+		level:  3,
+		interp: Bilinear,
+	}
+	for _, o := range opts {
+		o.applyWHash(&w)
+	}
+	if w.width == 0 || w.height == 0 {
+		return WHash{}, ErrInvalidSize
+	}
+	if w.level <= 0 {
+		return WHash{}, ErrInvalidLevel
+	}
+	return w, nil
+}
+
+// Calculate returns a perceptual image hash.
+func (wh WHash) Calculate(img image.Image) (hashtype.Hash, error) {
+	// Resize to (width * 2^level) x (height * 2^level) so that after
+	// `level` DWT passes the LL subband is exactly width×height.
+	scale := uint(1) << uint(wh.level)
+	rw := wh.width * scale
+	rh := wh.height * scale
+
+	r := imgproc.Resize(rw, rh, img, wh.interp.resizeType())
+	g, err := imgproc.Grayscale(r)
+	if err != nil {
+		return nil, err
+	}
+	mat := imgproc.GrayToF32(g)
+	imgproc.HaarDWT2D(mat, wh.level)
+
+	ll := wh.extractLL(mat)
+	med := wh.median(ll)
+	return wh.computeHash(ll, med), nil
+}
+
+func (wh WHash) extractLL(mat [][]float32) [][]float32 {
+	ll := make([][]float32, wh.height)
+	for r := uint(0); r < wh.height; r++ {
+		ll[r] = make([]float32, wh.width)
+		copy(ll[r], mat[r][:wh.width])
+	}
+	return ll
+}
+
+func (wh WHash) median(mat [][]float32) float32 {
+	vals := make([]float64, 0, wh.width*wh.height)
+	for _, row := range mat {
+		for _, v := range row {
+			vals = append(vals, float64(v))
+		}
+	}
+	sort.Float64s(vals)
+	n := len(vals)
+	if n%2 == 0 {
+		return float32((vals[n/2-1] + vals[n/2]) / 2)
+	}
+	return float32(vals[n/2])
+}
+
+func (wh WHash) computeHash(ll [][]float32, median float32) hashtype.Binary {
+	hash := make(hashtype.Binary, wh.width*wh.height/8)
+	var c uint
+	for _, row := range ll {
+		for _, v := range row {
+			if v > median {
+				_ = hash.Set(c)
+			}
+			c++
+		}
+	}
+	return hash
+}
+
+// Ensure WHash satisfies the Hasher interface.
+var _ Hasher = WHash{}

--- a/wavelet_test.go
+++ b/wavelet_test.go
@@ -1,0 +1,146 @@
+package imghash_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/ajdnik/imghash"
+	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/similarity"
+)
+
+var wHashCalculateTests = []struct {
+	filename   string
+	hash       hashtype.Binary
+	width      uint
+	height     uint
+	level      int
+	resizeType Interpolation
+}{
+	{"assets/lena.jpg", hashtype.Binary{125, 25, 189, 145, 208, 208, 241, 49}, 8, 8, 3, Bilinear},
+	{"assets/baboon.jpg", hashtype.Binary{128, 195, 252, 60, 61, 25, 71, 61}, 8, 8, 3, Bilinear},
+	{"assets/cat.jpg", hashtype.Binary{255, 255, 31, 7, 3, 1, 0, 47}, 8, 8, 3, Bilinear},
+	{"assets/monarch.jpg", hashtype.Binary{1, 9, 19, 252, 191, 223, 230, 64}, 8, 8, 3, Bilinear},
+	{"assets/peppers.jpg", hashtype.Binary{247, 225, 134, 180, 62, 50, 34, 135}, 8, 8, 3, Bilinear},
+	{"assets/tulips.jpg", hashtype.Binary{13, 102, 92, 90, 250, 122, 60, 6}, 8, 8, 3, Bilinear},
+}
+
+func TestWHash_Calculate(t *testing.T) {
+	for _, tt := range wHashCalculateTests {
+		t.Run(tt.filename, func(t *testing.T) {
+			hash, err := NewWHash(WithSize(tt.width, tt.height), WithLevel(tt.level), WithInterpolation(tt.resizeType))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img, err := OpenImage(tt.filename)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.filename, err)
+			}
+			result, err := hash.Calculate(img)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			res := result.(hashtype.Binary)
+			if !res.Equal(tt.hash) {
+				t.Errorf("got %v, want %v", res, tt.hash)
+			}
+		})
+	}
+}
+
+func ExampleWHash_Calculate() {
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		panic(err)
+	}
+	wh, err := NewWHash()
+	if err != nil {
+		panic(err)
+	}
+	hash, err := wh.Calculate(img)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hash)
+	// Output: [255 255 31 7 3 1 0 47]
+}
+
+var wHashDistanceTests = []struct {
+	firstImage  string
+	secondImage string
+	distance    similarity.Distance
+	width       uint
+	height      uint
+	level       int
+	resizeType  Interpolation
+}{
+	{"assets/lena.jpg", "assets/cat.jpg", 32, 8, 8, 3, Bilinear},
+	{"assets/lena.jpg", "assets/monarch.jpg", 34, 8, 8, 3, Bilinear},
+	{"assets/baboon.jpg", "assets/cat.jpg", 34, 8, 8, 3, Bilinear},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 30, 8, 8, 3, Bilinear},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 32, 8, 8, 3, Bilinear},
+}
+
+func TestWHash_Distance(t *testing.T) {
+	for _, tt := range wHashDistanceTests {
+		t.Run(fmt.Sprintf("%v %v", tt.firstImage, tt.secondImage), func(t *testing.T) {
+			hash, err := NewWHash(WithSize(tt.width, tt.height), WithLevel(tt.level), WithInterpolation(tt.resizeType))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img1, err := OpenImage(tt.firstImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.firstImage, err)
+			}
+			img2, err := OpenImage(tt.secondImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.secondImage, err)
+			}
+			h1, err := hash.Calculate(img1)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.firstImage, err)
+			}
+			h2, err := hash.Calculate(img2)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
+			}
+			dist, err := similarity.Hamming(h1, h2)
+			if err != nil {
+				t.Fatalf("failed to compute distance: %v", err)
+			}
+			if !dist.Equal(tt.distance) {
+				t.Errorf("got %v, want %v", dist, tt.distance)
+			}
+		})
+	}
+}
+
+func TestNewWHash_defaults(t *testing.T) {
+	wh, err := NewWHash()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	_, err = wh.Calculate(img)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewWHash_invalidSize(t *testing.T) {
+	_, err := NewWHash(WithSize(0, 8))
+	if err != ErrInvalidSize {
+		t.Errorf("got %v, want ErrInvalidSize", err)
+	}
+}
+
+func TestNewWHash_invalidLevel(t *testing.T) {
+	_, err := NewWHash(WithLevel(0))
+	if err != ErrInvalidLevel {
+		t.Errorf("got %v, want ErrInvalidLevel", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add a new **Wavelet Hash (wHash)** perceptual hashing algorithm based on the Haar discrete wavelet transform
- Implement a multi-level 2-D Haar DWT in the internal `imgproc` package
- Document the new algorithm in the README alongside the existing eight algorithms

## Details

The wavelet hash resizes the input image to `(width × 2^level) × (height × 2^level)` (default 64×64), converts to grayscale, and applies a multi-level Haar DWT. The low-frequency LL subband (default 8×8) is thresholded against its median to produce a 64-bit binary hash comparable via Hamming distance.

### New files
| File | Purpose |
|------|---------|
| `wavelet.go` | `WHash` struct, `NewWHash()` constructor, `Calculate()` method |
| `wavelet_test.go` | Hash-value, distance, validation, and `Example` tests |

### Modified files
| File | Change |
|------|--------|
| `internal/imgproc/transform.go` | Added `HaarDWT2D` with `haarRows`/`haarCols` helpers |
| `internal/imgproc/transform_test.go` | Tests for 1-level, 2-level, and empty-input Haar DWT |
| `options.go` | `WHashOption` interface, `levelOption` type, `WithLevel()` constructor; wired `sizeOption`/`interpolationOption` to `WHash` |
| `options_typecheck_test.go` | Compile-time assertions for `WHashOption` |
| `imghash.go` | Added `ErrInvalidLevel`; listed `WHash` in `Hasher` doc comment |
| `README.md` | Algorithm count → 9; new wHash section with usage, options table, and reference link |

## Type of Change

- [x] `feat` (new feature)
- [x] `docs` (documentation only)
- [x] `test` (tests only)

## Validation

```bash
go test ./... -count=1
```

All 4 packages pass (imghash, hashtype, internal/imgproc, similarity).

## Checklist

- [x] I ran relevant checks locally (`go test ./...`).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

None. This is a purely additive change.