### PR TITLE
feat: Local Binary Pattern Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can also call `h1.Distance(h2)` directly on any hash value.
 
 ## Perceptual Hash Algorithms
 
-The library supports 9 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
+The library supports 10 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
 
 Every constructor accepts functional options. Call with no arguments for defaults, or pass `With*` options to customize:
 
@@ -218,6 +218,23 @@ hash, err := bm.Calculate(img)
 | `WithBlockMeanMethod(m)` | `Direct` |
 
 Block mean methods: `Direct`, `Overlap`, `Rotation`, `RotationOverlap`.
+
+#### Local Binary Pattern (LBP) Hash
+
+Computes a 3x3 Local Binary Pattern code for each pixel and builds a normalized 256-bin histogram per grid cell, producing a uint8 vector. The grid can be increased for spatially-aware hashing. See [Local binary patterns](https://en.wikipedia.org/wiki/Local_binary_patterns) for more information.
+
+```go
+lbp, err := imghash.NewLBP()
+hash, err := lbp.Calculate(img)
+```
+
+| Option | Default |
+|--------|---------|
+| `WithSize(w, h)` | 256, 256 |
+| `WithInterpolation(i)` | `Bilinear` |
+| `WithGridSize(x, y)` | 1, 1 |
+
+With the default 1x1 grid the hash is a 256-element uint8 vector. Set `WithGridSize(4, 4)` for a 4096-element spatially-aware hash.
 
 #### Radial Variance Hash
 

--- a/imghash.go
+++ b/imghash.go
@@ -11,7 +11,7 @@ import (
 // Hasher computes a perceptual hash from an image.
 // It is implemented by all hash algorithms in this package:
 // Average, Difference, PHash, Median, BlockMean, MarrHildreth,
-// RadialVariance, ColorMoment, and WHash.
+// RadialVariance, ColorMoment, WHash, and LBP.
 type Hasher interface {
 	Calculate(image.Image) (hashtype.Hash, error)
 }
@@ -55,4 +55,6 @@ var (
 	ErrInvalidSigma = errors.New("imghash: sigma must not be negative")
 	// ErrInvalidLevel is returned when the wavelet decomposition level is not positive.
 	ErrInvalidLevel = errors.New("imghash: level must be greater than zero")
+	// ErrInvalidGridSize is returned when grid width or height is zero.
+	ErrInvalidGridSize = errors.New("imghash: grid size dimensions must be greater than zero")
 )

--- a/lbp.go
+++ b/lbp.go
@@ -1,0 +1,135 @@
+package imghash
+
+import (
+	"image"
+
+	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/internal/imgproc"
+)
+
+// LBP is a perceptual hash based on Local Binary Patterns.
+// It computes a basic 3×3 LBP code for each pixel, divides the image into
+// a grid of cells, builds a 256-bin histogram per cell, and concatenates
+// them into a single hash vector.
+//
+// See https://en.wikipedia.org/wiki/Local_binary_patterns for more information.
+type LBP struct {
+	// Resized image width.
+	width uint
+	// Resized image height.
+	height uint
+	// Resize interpolation method.
+	interp Interpolation
+	// Number of horizontal grid cells.
+	gridX uint
+	// Number of vertical grid cells.
+	gridY uint
+}
+
+// NewLBP creates a new LBP hash with the given options.
+// Without options, sensible defaults are used.
+func NewLBP(opts ...LBPOption) (LBP, error) {
+	l := LBP{
+		width:  256,
+		height: 256,
+		interp: Bilinear,
+		gridX:  1,
+		gridY:  1,
+	}
+	for _, o := range opts {
+		o.applyLBP(&l)
+	}
+	if l.width == 0 || l.height == 0 {
+		return LBP{}, ErrInvalidSize
+	}
+	if l.gridX == 0 || l.gridY == 0 {
+		return LBP{}, ErrInvalidGridSize
+	}
+	return l, nil
+}
+
+// Calculate returns a perceptual image hash.
+func (lh LBP) Calculate(img image.Image) (hashtype.Hash, error) {
+	r := imgproc.Resize(lh.width, lh.height, img, lh.interp.resizeType())
+	g, err := imgproc.Grayscale(r)
+	if err != nil {
+		return nil, err
+	}
+	bounds := g.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	lbpImg := lh.computeLBP(g, w, h)
+	return lh.computeHash(lbpImg, w, h), nil
+}
+
+// 8-neighbor offsets starting from the right, going clockwise.
+var lbpDX = [8]int{1, 1, 0, -1, -1, -1, 0, 1}
+var lbpDY = [8]int{0, 1, 1, 1, 0, -1, -1, -1}
+
+// computeLBP builds the LBP code image from a grayscale image.
+// Border pixels compare out-of-bounds neighbors as zero.
+func (lh LBP) computeLBP(img *image.Gray, w, h int) []uint8 {
+	ox := img.Bounds().Min.X
+	oy := img.Bounds().Min.Y
+	result := make([]uint8, w*h)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			center := img.GrayAt(x+ox, y+oy).Y
+			var code uint8
+			for k := 0; k < 8; k++ {
+				nx, ny := x+lbpDX[k], y+lbpDY[k]
+				if nx >= 0 && nx < w && ny >= 0 && ny < h {
+					if img.GrayAt(nx+ox, ny+oy).Y >= center {
+						code |= 1 << uint(k)
+					}
+				}
+			}
+			result[y*w+x] = code
+		}
+	}
+	return result
+}
+
+// computeHash builds a UInt8 hash from the LBP code image by computing
+// a normalized 256-bin histogram for each grid cell.
+func (lh LBP) computeHash(lbpImg []uint8, w, h int) hashtype.UInt8 {
+	gx, gy := int(lh.gridX), int(lh.gridY)
+	hash := make(hashtype.UInt8, gx*gy*256)
+	cellW := w / gx
+	cellH := h / gy
+
+	for cy := 0; cy < gy; cy++ {
+		for cx := 0; cx < gx; cx++ {
+			startX := cx * cellW
+			startY := cy * cellH
+			endX := startX + cellW
+			endY := startY + cellH
+			if cx == gx-1 {
+				endX = w
+			}
+			if cy == gy-1 {
+				endY = h
+			}
+
+			var hist [256]float64
+			var maxVal float64
+			for y := startY; y < endY; y++ {
+				for x := startX; x < endX; x++ {
+					hist[lbpImg[y*w+x]]++
+				}
+			}
+			for i := range hist {
+				if hist[i] > maxVal {
+					maxVal = hist[i]
+				}
+			}
+
+			offset := (cy*gx + cx) * 256
+			if maxVal > 0 {
+				for i := 0; i < 256; i++ {
+					hash[offset+i] = uint8(hist[i] * 255 / maxVal)
+				}
+			}
+		}
+	}
+	return hash
+}

--- a/lbp_test.go
+++ b/lbp_test.go
@@ -1,0 +1,166 @@
+package imghash_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/ajdnik/imghash"
+	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/similarity"
+)
+
+var lbpCalculateTests = []struct {
+	filename   string
+	hash       hashtype.UInt8
+	width      uint
+	height     uint
+	resizeType Interpolation
+	gridX      uint
+	gridY      uint
+}{
+	{"assets/lena.jpg", hashtype.UInt8{82, 18, 10, 16, 40, 5, 19, 51, 15, 2, 1, 1, 21, 6, 14, 66, 14, 2, 1, 1, 4, 0, 2, 3, 16, 1, 1, 1, 33, 2, 39, 30, 10, 2, 2, 1, 3, 0, 1, 4, 1, 0, 0, 0, 2, 0, 1, 6, 16, 1, 1, 2, 7, 0, 4, 3, 46, 2, 2, 2, 131, 3, 35, 28, 39, 4, 3, 8, 10, 1, 3, 6, 6, 0, 0, 0, 4, 0, 1, 2, 7, 0, 0, 0, 0, 0, 0, 0, 11, 0, 1, 1, 5, 0, 3, 3, 18, 4, 2, 4, 4, 0, 2, 3, 2, 0, 0, 0, 3, 0, 2, 3, 47, 3, 5, 3, 5, 0, 3, 6, 174, 4, 9, 6, 113, 5, 33, 33, 19, 27, 1, 66, 7, 13, 2, 226, 3, 3, 0, 2, 3, 5, 1, 59, 3, 2, 0, 3, 0, 0, 0, 4, 3, 1, 0, 3, 2, 3, 2, 29, 1, 2, 0, 3, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 7, 2, 2, 0, 2, 0, 0, 0, 7, 2, 3, 0, 7, 6, 5, 4, 52, 24, 48, 3, 203, 3, 7, 3, 166, 3, 4, 0, 8, 2, 3, 1, 36, 8, 5, 0, 5, 0, 1, 0, 7, 5, 4, 0, 5, 3, 4, 3, 29, 22, 54, 1, 59, 2, 4, 2, 51, 2, 4, 0, 5, 2, 2, 1, 30, 66, 42, 8, 39, 4, 4, 5, 45, 59, 37, 6, 56, 33, 35, 30, 255}, 256, 256, Bilinear, 1, 1},
+	{"assets/baboon.jpg", hashtype.UInt8{197, 69, 24, 31, 40, 8, 28, 46, 25, 8, 3, 4, 30, 12, 31, 59, 71, 12, 10, 6, 9, 1, 13, 5, 37, 6, 3, 4, 44, 7, 65, 41, 26, 9, 4, 4, 5, 0, 5, 6, 3, 1, 0, 0, 4, 2, 6, 12, 36, 6, 5, 3, 9, 0, 7, 5, 41, 4, 4, 4, 75, 4, 42, 34, 42, 8, 7, 9, 6, 1, 4, 6, 6, 1, 1, 1, 5, 1, 4, 4, 10, 1, 0, 0, 0, 0, 1, 0, 10, 0, 1, 0, 5, 0, 4, 3, 30, 12, 3, 6, 3, 0, 4, 5, 5, 2, 0, 1, 4, 1, 6, 9, 45, 5, 6, 4, 4, 0, 5, 5, 91, 6, 10, 7, 56, 4, 45, 33, 25, 31, 3, 38, 5, 9, 4, 79, 5, 5, 0, 3, 4, 6, 5, 46, 8, 5, 1, 4, 0, 0, 2, 5, 5, 4, 0, 4, 6, 5, 11, 35, 2, 3, 0, 4, 0, 1, 0, 8, 1, 0, 0, 0, 0, 1, 1, 9, 4, 4, 0, 3, 1, 0, 0, 6, 4, 4, 0, 6, 9, 7, 8, 45, 27, 41, 4, 78, 4, 4, 4, 50, 4, 7, 0, 9, 4, 6, 4, 40, 13, 5, 2, 4, 0, 0, 1, 3, 7, 5, 1, 6, 4, 4, 8, 33, 33, 60, 4, 40, 3, 4, 6, 39, 5, 10, 1, 8, 5, 10, 10, 74, 62, 42, 11, 32, 4, 3, 9, 32, 49, 33, 8, 46, 41, 31, 73, 255}, 256, 256, Bilinear, 1, 1},
+	{"assets/cat.jpg", hashtype.UInt8{140, 97, 12, 39, 15, 6, 22, 68, 13, 10, 1, 2, 24, 14, 62, 193, 107, 18, 7, 6, 6, 0, 9, 7, 42, 5, 2, 2, 73, 7, 186, 105, 14, 8, 1, 3, 1, 0, 1, 4, 1, 0, 0, 0, 1, 0, 3, 16, 53, 7, 3, 3, 3, 0, 4, 3, 41, 2, 2, 1, 85, 2, 85, 41, 16, 6, 1, 2, 2, 0, 1, 3, 1, 0, 0, 0, 1, 0, 2, 2, 6, 1, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 3, 0, 3, 2, 28, 11, 2, 5, 2, 0, 3, 4, 2, 1, 0, 0, 3, 0, 5, 8, 87, 8, 4, 3, 2, 0, 4, 3, 70, 3, 3, 2, 59, 3, 61, 30, 18, 44, 0, 35, 1, 3, 1, 66, 3, 4, 0, 2, 2, 6, 5, 73, 11, 6, 0, 3, 0, 0, 1, 2, 4, 3, 0, 1, 5, 3, 9, 31, 1, 2, 0, 2, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 5, 3, 3, 0, 2, 0, 0, 0, 1, 2, 1, 0, 2, 4, 2, 5, 19, 30, 82, 1, 85, 1, 2, 3, 55, 3, 5, 0, 3, 3, 5, 4, 46, 17, 6, 1, 3, 0, 0, 1, 3, 8, 3, 0, 2, 4, 3, 7, 23, 74, 198, 4, 94, 2, 3, 5, 58, 5, 9, 0, 5, 6, 7, 12, 103, 255, 121, 15, 45, 3, 3, 11, 30, 99, 36, 7, 22, 60, 23, 114, 217}, 256, 256, Bilinear, 1, 1},
+	{"assets/monarch.jpg", hashtype.UInt8{46, 9, 7, 13, 26, 2, 21, 54, 6, 1, 0, 1, 17, 1, 27, 55, 11, 2, 1, 1, 2, 0, 2, 2, 12, 1, 1, 1, 52, 2, 64, 41, 7, 0, 1, 1, 3, 0, 1, 2, 0, 0, 0, 0, 1, 0, 1, 3, 14, 0, 1, 1, 4, 0, 1, 1, 42, 1, 1, 2, 146, 3, 47, 27, 26, 2, 4, 6, 4, 0, 2, 4, 2, 0, 0, 0, 2, 0, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 3, 0, 2, 4, 17, 2, 1, 2, 2, 0, 1, 1, 1, 0, 0, 0, 1, 0, 0, 2, 55, 2, 3, 2, 3, 0, 2, 2, 129, 3, 5, 3, 97, 8, 30, 32, 6, 13, 0, 38, 2, 3, 1, 129, 0, 0, 0, 1, 1, 1, 1, 46, 0, 0, 0, 1, 0, 0, 0, 2, 0, 1, 0, 1, 2, 2, 4, 33, 0, 1, 0, 2, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 3, 1, 1, 0, 1, 0, 0, 0, 4, 2, 1, 0, 2, 9, 7, 3, 43, 18, 56, 1, 194, 1, 3, 1, 112, 1, 2, 0, 8, 1, 2, 1, 36, 1, 2, 0, 3, 0, 0, 0, 5, 2, 2, 0, 6, 1, 2, 2, 35, 29, 64, 1, 64, 1, 2, 1, 39, 1, 3, 0, 2, 1, 3, 2, 23, 57, 35, 2, 30, 2, 3, 2, 31, 50, 31, 3, 41, 42, 38, 24, 255}, 256, 256, Bilinear, 1, 1},
+	{"assets/peppers.jpg", hashtype.UInt8{72, 28, 12, 29, 25, 4, 24, 73, 8, 1, 1, 2, 16, 4, 37, 111, 22, 5, 2, 3, 4, 0, 4, 4, 18, 2, 2, 3, 48, 3, 130, 72, 9, 3, 1, 1, 2, 0, 2, 2, 0, 0, 0, 0, 2, 0, 2, 4, 19, 3, 2, 2, 4, 0, 1, 3, 44, 2, 2, 2, 111, 3, 45, 32, 27, 5, 3, 6, 6, 0, 4, 5, 3, 0, 0, 0, 3, 0, 2, 4, 4, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 4, 1, 3, 4, 22, 4, 2, 2, 3, 0, 2, 2, 1, 0, 0, 0, 2, 0, 2, 3, 61, 4, 2, 3, 4, 0, 2, 3, 191, 3, 4, 4, 79, 3, 33, 28, 14, 32, 2, 80, 4, 6, 3, 224, 1, 1, 0, 3, 2, 4, 2, 71, 2, 3, 0, 4, 0, 0, 0, 6, 1, 1, 0, 4, 2, 2, 5, 43, 1, 2, 0, 3, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 6, 2, 3, 0, 3, 0, 0, 0, 6, 2, 2, 0, 4, 4, 3, 4, 39, 31, 87, 3, 211, 4, 6, 5, 147, 2, 3, 0, 7, 1, 3, 2, 58, 5, 5, 0, 6, 0, 0, 0, 7, 3, 3, 0, 5, 2, 2, 3, 39, 49, 133, 2, 90, 2, 5, 3, 60, 3, 4, 0, 5, 2, 4, 4, 49, 119, 81, 5, 48, 4, 4, 3, 42, 63, 36, 5, 45, 34, 29, 34, 255}, 256, 256, Bilinear, 1, 1},
+	{"assets/tulips.jpg", hashtype.UInt8{101, 16, 17, 21, 78, 5, 28, 49, 16, 2, 1, 1, 24, 5, 23, 67, 17, 2, 2, 2, 4, 0, 4, 2, 19, 1, 1, 1, 45, 2, 60, 36, 16, 1, 2, 1, 11, 0, 2, 3, 1, 0, 0, 0, 2, 0, 1, 5, 21, 2, 2, 1, 14, 0, 3, 2, 52, 1, 3, 3, 217, 3, 54, 35, 89, 4, 10, 15, 23, 0, 5, 6, 10, 0, 0, 1, 5, 0, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 16, 0, 0, 0, 6, 0, 3, 3, 32, 5, 2, 3, 5, 0, 2, 3, 2, 0, 0, 0, 2, 0, 1, 1, 57, 2, 4, 2, 6, 0, 2, 2, 255, 3, 11, 8, 109, 4, 31, 28, 18, 22, 1, 52, 10, 16, 2, 225, 2, 1, 0, 3, 2, 4, 2, 64, 2, 1, 0, 1, 0, 0, 0, 3, 2, 1, 0, 2, 3, 2, 4, 37, 2, 1, 0, 3, 0, 1, 0, 10, 0, 0, 0, 0, 0, 0, 0, 4, 2, 2, 0, 2, 1, 0, 0, 8, 3, 2, 0, 8, 10, 8, 5, 82, 36, 57, 2, 233, 5, 6, 2, 106, 2, 3, 0, 10, 1, 1, 1, 30, 4, 3, 0, 3, 0, 0, 0, 3, 4, 3, 0, 7, 1, 2, 2, 28, 28, 74, 2, 67, 3, 3, 1, 35, 1, 4, 0, 4, 1, 1, 1, 18, 81, 46, 4, 45, 4, 4, 2, 30, 75, 47, 5, 90, 34, 30, 20, 228}, 256, 256, Bilinear, 1, 1},
+}
+
+func TestLBP_Calculate(t *testing.T) {
+	for _, tt := range lbpCalculateTests {
+		t.Run(tt.filename, func(t *testing.T) {
+			hash, err := NewLBP(WithSize(tt.width, tt.height), WithInterpolation(tt.resizeType), WithGridSize(tt.gridX, tt.gridY))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img, err := OpenImage(tt.filename)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.filename, err)
+			}
+			result, err := hash.Calculate(img)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			res := result.(hashtype.UInt8)
+			if !res.Equal(tt.hash) {
+				t.Errorf("got %v, want %v", res, tt.hash)
+			}
+		})
+	}
+}
+
+func ExampleLBP_Calculate() {
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		panic(err)
+	}
+	lbp, err := NewLBP()
+	if err != nil {
+		panic(err)
+	}
+	hash, err := lbp.Calculate(img)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hash)
+	// Output: [140 97 12 39 15 6 22 68 13 10 1 2 24 14 62 193 107 18 7 6 6 0 9 7 42 5 2 2 73 7 186 105 14 8 1 3 1 0 1 4 1 0 0 0 1 0 3 16 53 7 3 3 3 0 4 3 41 2 2 1 85 2 85 41 16 6 1 2 2 0 1 3 1 0 0 0 1 0 2 2 6 1 0 0 0 0 0 0 2 0 0 0 3 0 3 2 28 11 2 5 2 0 3 4 2 1 0 0 3 0 5 8 87 8 4 3 2 0 4 3 70 3 3 2 59 3 61 30 18 44 0 35 1 3 1 66 3 4 0 2 2 6 5 73 11 6 0 3 0 0 1 2 4 3 0 1 5 3 9 31 1 2 0 2 0 0 0 3 0 0 0 0 0 0 0 5 3 3 0 2 0 0 0 1 2 1 0 2 4 2 5 19 30 82 1 85 1 2 3 55 3 5 0 3 3 5 4 46 17 6 1 3 0 0 1 3 8 3 0 2 4 3 7 23 74 198 4 94 2 3 5 58 5 9 0 5 6 7 12 103 255 121 15 45 3 3 11 30 99 36 7 22 60 23 114 217]
+}
+
+var lbpDistanceTests = []struct {
+	firstImage  string
+	secondImage string
+	distance    similarity.Distance
+	width       uint
+	height      uint
+	resizeType  Interpolation
+	gridX       uint
+	gridY       uint
+}{
+	{"assets/lena.jpg", "assets/cat.jpg", 482.6240773106953, 256, 256, Bilinear, 1, 1},
+	{"assets/lena.jpg", "assets/monarch.jpg", 148.6674140489435, 256, 256, Bilinear, 1, 1},
+	{"assets/baboon.jpg", "assets/cat.jpg", 361.8535615411295, 256, 256, Bilinear, 1, 1},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 337.358859376777, 256, 256, Bilinear, 1, 1},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 228.75314205492347, 256, 256, Bilinear, 1, 1},
+}
+
+func TestLBP_Distance(t *testing.T) {
+	for _, tt := range lbpDistanceTests {
+		t.Run(fmt.Sprintf("%v %v", tt.firstImage, tt.secondImage), func(t *testing.T) {
+			hash, err := NewLBP(WithSize(tt.width, tt.height), WithInterpolation(tt.resizeType), WithGridSize(tt.gridX, tt.gridY))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img1, err := OpenImage(tt.firstImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.firstImage, err)
+			}
+			img2, err := OpenImage(tt.secondImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.secondImage, err)
+			}
+			h1, err := hash.Calculate(img1)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.firstImage, err)
+			}
+			h2, err := hash.Calculate(img2)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
+			}
+			dist := similarity.L2(h1, h2)
+			if !dist.Equal(tt.distance) {
+				t.Errorf("got %v, want %v", dist, tt.distance)
+			}
+		})
+	}
+}
+
+func TestNewLBP_defaults(t *testing.T) {
+	lbp, err := NewLBP()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	h, err := lbp.Calculate(img)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.Len() != 256 {
+		t.Errorf("expected hash length 256, got %d", h.Len())
+	}
+}
+
+func TestNewLBP_invalidSize(t *testing.T) {
+	_, err := NewLBP(WithSize(0, 0))
+	if err != ErrInvalidSize {
+		t.Errorf("expected ErrInvalidSize, got %v", err)
+	}
+}
+
+func TestNewLBP_invalidGridSize(t *testing.T) {
+	_, err := NewLBP(WithGridSize(0, 0))
+	if err != ErrInvalidGridSize {
+		t.Errorf("expected ErrInvalidGridSize, got %v", err)
+	}
+}
+
+func TestNewLBP_gridSize(t *testing.T) {
+	lbp, err := NewLBP(WithGridSize(2, 2))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	h, err := lbp.Calculate(img)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h.Len() != 2*2*256 {
+		t.Errorf("expected hash length %d, got %d", 2*2*256, h.Len())
+	}
+}

--- a/options.go
+++ b/options.go
@@ -30,6 +30,9 @@ type ColorMomentOption interface{ applyColorMoment(*ColorMoment) }
 // WHashOption configures the WHash algorithm.
 type WHashOption interface{ applyWHash(*WHash) }
 
+// LBPOption configures the LBP hash algorithm.
+type LBPOption interface{ applyLBP(*LBP) }
+
 // --- concrete option types ---
 
 type sizeOption struct{ width, height uint }
@@ -42,6 +45,7 @@ func (o sizeOption) applyBlockMean(b *BlockMean)       { b.rWidth, b.rHeight = o
 func (o sizeOption) applyMarrHildreth(m *MarrHildreth) { m.width, m.height = o.width, o.height }
 func (o sizeOption) applyColorMoment(c *ColorMoment)   { c.width, c.height = o.width, o.height }
 func (o sizeOption) applyWHash(w *WHash)               { w.width, w.height = o.width, o.height }
+func (o sizeOption) applyLBP(l *LBP)                   { l.width, l.height = o.width, o.height }
 
 type interpolationOption struct{ interp Interpolation }
 
@@ -53,6 +57,7 @@ func (o interpolationOption) applyBlockMean(b *BlockMean)       { b.interp = o.i
 func (o interpolationOption) applyMarrHildreth(m *MarrHildreth) { m.interp = o.interp }
 func (o interpolationOption) applyColorMoment(c *ColorMoment)   { c.interp = o.interp }
 func (o interpolationOption) applyWHash(w *WHash)               { w.interp = o.interp }
+func (o interpolationOption) applyLBP(l *LBP)                   { l.interp = o.interp }
 
 type kernelSizeOption struct{ size int }
 
@@ -89,16 +94,20 @@ type levelOption struct{ level int }
 
 func (o levelOption) applyWHash(w *WHash) { w.level = o.level }
 
+type gridSizeOption struct{ x, y uint }
+
+func (o gridSizeOption) applyLBP(l *LBP) { l.gridX, l.gridY = o.x, o.y }
+
 // --- public constructors ---
 
 // WithSize sets the resize dimensions used during hash computation.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, and WHash.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, and LBP.
 func WithSize(width, height uint) sizeOption {
 	return sizeOption{width, height}
 }
 
 // WithInterpolation sets the resize interpolation method.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, and WHash.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, and LBP.
 func WithInterpolation(interp Interpolation) interpolationOption {
 	return interpolationOption{interp}
 }
@@ -149,4 +158,11 @@ func WithAngles(angles int) anglesOption {
 // Applies to WHash.
 func WithLevel(level int) levelOption {
 	return levelOption{level}
+}
+
+// WithGridSize sets the number of grid cells used to divide the image for
+// spatial histogram computation.
+// Applies to LBP.
+func WithGridSize(x, y uint) gridSizeOption {
+	return gridSizeOption{x, y}
 }

--- a/options_typecheck_test.go
+++ b/options_typecheck_test.go
@@ -39,3 +39,7 @@ var _ ColorMomentOption = WithSigma(0)
 var _ WHashOption = WithSize(0, 0)
 var _ WHashOption = WithInterpolation(Bilinear)
 var _ WHashOption = WithLevel(0)
+
+var _ LBPOption = WithSize(0, 0)
+var _ LBPOption = WithInterpolation(Bilinear)
+var _ LBPOption = WithGridSize(0, 0)


### PR DESCRIPTION
## Summary

- Add Local Binary Pattern (LBP) perceptual hash algorithm (`NewLBP`, `LBP.Calculate`)
- The algorithm resizes the image, converts to grayscale, computes a 3x3 LBP code per pixel, and builds a normalized 256-bin histogram per grid cell, producing a `UInt8` hash
- Supports `WithSize`, `WithInterpolation`, and a new `WithGridSize` option for spatially-aware hashing

## Related Issue

N/A

## Type of Change

- [x] `feat` (new feature)
- [ ] `fix` (bug fix)
- [ ] `docs` (documentation only)
- [ ] `test` (tests only)
- [ ] `chore` (maintenance/refactor/tooling)
- [ ] Breaking change

## Changed Files

| File | Description |
|------|-------------|
| `lbp.go` | New LBP hash algorithm implementation |
| `lbp_test.go` | Calculate tests (6 images), distance tests (5 pairs), validation error tests, grid-size test, and an example |
| `options.go` | `LBPOption` interface, `gridSizeOption` type, `WithGridSize` constructor, wired `sizeOption`/`interpolationOption` to LBP |
| `options_typecheck_test.go` | Compile-time assertions for `LBPOption` |
| `imghash.go` | Added `ErrInvalidGridSize`, updated `Hasher` doc comment |
| `README.md` | Added LBP section to algorithm docs, updated algorithm count to 10 |

## Validation

All existing and new tests pass:

```bash
go test ./... -count=1
```

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

None. This is a purely additive change.