### PR TITLE
feat: Histogram Of Oriented Gradients Hash

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,12 +6,9 @@ change in your code when migrating from v1.
 ## 1. Update the dependency
 
 ```bash
-go get github.com/ajdnik/imghash@latest
+go get github.com/ajdnik/imghash/v2@latest
 go mod tidy
 ```
-
-If you consume a tagged major-version module path, use the corresponding import
-path for that major version (for example `.../v2`).
 
 ## 2. Replace `New*WithParams` constructors with functional options
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Block mean methods: `Direct`, `Overlap`, `Rotation`, `RotationOverlap`.
 
 #### Local Binary Pattern (LBP) Hash
 
-Computes a 3x3 Local Binary Pattern code for each pixel and builds a normalized 256-bin histogram per grid cell, producing a uint8 vector. The grid can be increased for spatially-aware hashing. See [Local binary patterns](https://en.wikipedia.org/wiki/Local_binary_patterns) for more information.
+Computes a 3x3 Local Binary Pattern code for each pixel and builds a normalized 256-bin histogram per grid cell, producing a uint8 vector. The grid can be increased for spatially-aware hashing. Based on [Multiresolution Gray-Scale and Rotation Invariant Texture Classification with Local Binary Patterns](https://ieeexplore.ieee.org/document/1017623) by Ojala et al.
 
 ```go
 lbp, err := imghash.NewLBP()
@@ -238,7 +238,7 @@ With the default 1x1 grid the hash is a 256-element uint8 vector. Set `WithGridS
 
 #### HOG Hash (Histogram of Oriented Gradients)
 
-Computes gradient magnitudes and orientations at each pixel, divides the image into square cells, and builds a magnitude-weighted orientation histogram per cell. The histograms are normalized and concatenated into a uint8 vector. See [Histogram of oriented gradients](https://en.wikipedia.org/wiki/Histogram_of_oriented_gradients) for more information.
+Computes gradient magnitudes and orientations at each pixel, divides the image into square cells, and builds a magnitude-weighted orientation histogram per cell. The histograms are normalized and concatenated into a uint8 vector. Based on [Histograms of Oriented Gradients for Human Detection](https://ieeexplore.ieee.org/document/1467360) by Dalal and Triggs.
 
 ```go
 hog, err := imghash.NewHOGHash()

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![CI](https://github.com/ajdnik/imghash/workflows/ci/badge.svg "CI status")](https://github.com/ajdnik/imghash/actions?query=workflow%3Aci)
 [![Coverage Status](https://coveralls.io/repos/github/ajdnik/imghash/badge.svg?branch=main)](https://coveralls.io/github/ajdnik/imghash?branch=main)
-[![GoDoc](https://godoc.org/github.com/ajdnik/imghash?status.svg "GoDoc")](https://godoc.org/github.com/ajdnik/imghash)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ajdnik/imghash)](https://goreportcard.com/report/github.com/ajdnik/imghash)
+[![Go Reference](https://pkg.go.dev/badge/github.com/ajdnik/imghash/v2.svg)](https://pkg.go.dev/github.com/ajdnik/imghash/v2)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ajdnik/imghash/v2)](https://goreportcard.com/report/github.com/ajdnik/imghash/v2)
 [![License MIT](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/ajdnik/imghash/blob/main/LICENSE)
 
 Go implementation of multiple perceptual hash algorithms for images. Perceptual hash functions are analogous if features are similar, whereas cryptographic hashing relies on the avalanche effect of a small change in input value creating a drastic change in output value.
@@ -20,12 +20,12 @@ Go implementation of multiple perceptual hash algorithms for images. Perceptual 
 Using imghash is easy. First, use `go get` to install the latest version
 of the library. This command will install the library and its dependencies:
 
-    go get -u github.com/ajdnik/imghash
+    go get -u github.com/ajdnik/imghash/v2
 
 Next, include imghash in your application:
 
 ```go
-import "github.com/ajdnik/imghash"
+import "github.com/ajdnik/imghash/v2"
 ```
 
 Most consumers only need the top-level `imghash` package. The core types (`Hash`, `Binary`, `UInt8`, `Float64`, `Distance`) are re-exported there. The `similarity` sub-package is available when you need a specific metric like PCC.
@@ -38,7 +38,7 @@ package main
 import (
   "fmt"
 
-  "github.com/ajdnik/imghash"
+  "github.com/ajdnik/imghash/v2"
 )
 
 func main() {
@@ -293,7 +293,7 @@ dist, err := imghash.Compare(h1, h2)
 For advanced use cases (e.g. Pearson Correlation), use the `similarity` sub-package:
 
 ```go
-import "github.com/ajdnik/imghash/similarity"
+import "github.com/ajdnik/imghash/v2/similarity"
 
 dist := similarity.L2(h1, h2)
 dist, err := similarity.PCC(h1, h2)

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can also call `h1.Distance(h2)` directly on any hash value.
 
 ## Perceptual Hash Algorithms
 
-The library supports 10 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
+The library supports 11 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
 
 Every constructor accepts functional options. Call with no arguments for defaults, or pass `With*` options to customize:
 
@@ -235,6 +235,24 @@ hash, err := lbp.Calculate(img)
 | `WithGridSize(x, y)` | 1, 1 |
 
 With the default 1x1 grid the hash is a 256-element uint8 vector. Set `WithGridSize(4, 4)` for a 4096-element spatially-aware hash.
+
+#### HOG Hash (Histogram of Oriented Gradients)
+
+Computes gradient magnitudes and orientations at each pixel, divides the image into square cells, and builds a magnitude-weighted orientation histogram per cell. The histograms are normalized and concatenated into a uint8 vector. See [Histogram of oriented gradients](https://en.wikipedia.org/wiki/Histogram_of_oriented_gradients) for more information.
+
+```go
+hog, err := imghash.NewHOGHash()
+hash, err := hog.Calculate(img)
+```
+
+| Option | Default |
+|--------|---------|
+| `WithSize(w, h)` | 256, 256 |
+| `WithInterpolation(i)` | `Bilinear` |
+| `WithCellSize(s)` | 8 |
+| `WithNumBins(n)` | 9 |
+
+With default settings the hash is a 9216-element uint8 vector (32×32 cells × 9 bins). Use `WithSize(32, 32)` for a compact 144-element hash (4×4 cells × 9 bins).
 
 #### Radial Variance Hash
 

--- a/average.go
+++ b/average.go
@@ -4,8 +4,8 @@ import (
 	"image"
 	"math"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // Average is a perceptual hash that uses the method described in Looks Like It by Dr. Neal Krawetz.

--- a/average_test.go
+++ b/average_test.go
@@ -5,9 +5,9 @@ import (
 
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var averageCalculateTests = []struct {

--- a/blockmean.go
+++ b/blockmean.go
@@ -3,8 +3,8 @@ package imghash
 import (
 	"image"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // BlockMean is a perceptual hash that uses the method described in

--- a/blockmean_test.go
+++ b/blockmean_test.go
@@ -5,9 +5,9 @@ import (
 
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var blockMeanCalculateTests = []struct {

--- a/colormoment.go
+++ b/colormoment.go
@@ -3,8 +3,8 @@ package imghash
 import (
 	"image"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // ColorMoment is a perceptual hash that uses the method described in

--- a/colormoment_test.go
+++ b/colormoment_test.go
@@ -5,9 +5,9 @@ import (
 
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var colorMomentCalculateTests = []struct {

--- a/convenience.go
+++ b/convenience.go
@@ -8,8 +8,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // OpenImage reads and decodes an image from the given file path.

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/ajdnik/imghash"
+	. "github.com/ajdnik/imghash/v2"
 )
 
 func TestOpenImage_nonexistent(t *testing.T) {

--- a/difference.go
+++ b/difference.go
@@ -3,8 +3,8 @@ package imghash
 import (
 	"image"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // Difference is a perceptual hash that uses the method described in Kinf of Like That by Dr. Neal Krawetz.

--- a/difference_test.go
+++ b/difference_test.go
@@ -7,9 +7,9 @@ import (
 	_ "image/png"
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var differenceCalculateTests = []struct {

--- a/example_test.go
+++ b/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/ajdnik/imghash"
+	. "github.com/ajdnik/imghash/v2"
 )
 
 func ExampleOpenImage() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ajdnik/imghash
+module github.com/ajdnik/imghash/v2
 
 go 1.25
 

--- a/hashtype/binary_test.go
+++ b/hashtype/binary_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/ajdnik/imghash/hashtype"
+	. "github.com/ajdnik/imghash/v2/hashtype"
 )
 
 var binaryStringTests = []struct {

--- a/hashtype/float64_test.go
+++ b/hashtype/float64_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/ajdnik/imghash/hashtype"
+	. "github.com/ajdnik/imghash/v2/hashtype"
 )
 
 var float64StringTests = []struct {

--- a/hashtype/uint8_test.go
+++ b/hashtype/uint8_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/ajdnik/imghash/hashtype"
+	. "github.com/ajdnik/imghash/v2/hashtype"
 )
 
 var uint8StringTests = []struct {

--- a/hoghash.go
+++ b/hoghash.go
@@ -1,0 +1,164 @@
+package imghash
+
+import (
+	"image"
+	"math"
+
+	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/internal/imgproc"
+)
+
+// HOGHash is a perceptual hash based on Histogram of Oriented Gradients.
+// It computes gradient magnitudes and orientations at each pixel, divides
+// the image into cells, builds an orientation histogram per cell weighted
+// by gradient magnitude, and concatenates them into a single hash vector.
+//
+// See https://en.wikipedia.org/wiki/Histogram_of_oriented_gradients for more information.
+type HOGHash struct {
+	// Resized image width.
+	width uint
+	// Resized image height.
+	height uint
+	// Resize interpolation method.
+	interp Interpolation
+	// Cell size in pixels (square cells).
+	cellSize uint
+	// Number of orientation bins (unsigned gradients, 0–180°).
+	numBins uint
+}
+
+// NewHOGHash creates a new HOGHash with the given options.
+// Without options, sensible defaults are used.
+func NewHOGHash(opts ...HOGHashOption) (HOGHash, error) {
+	h := HOGHash{
+		width:    256,
+		height:   256,
+		interp:   Bilinear,
+		cellSize: 8,
+		numBins:  9,
+	}
+	for _, o := range opts {
+		o.applyHOGHash(&h)
+	}
+	if h.width == 0 || h.height == 0 {
+		return HOGHash{}, ErrInvalidSize
+	}
+	if h.cellSize == 0 {
+		return HOGHash{}, ErrInvalidCellSize
+	}
+	if h.numBins == 0 {
+		return HOGHash{}, ErrInvalidNumBins
+	}
+	return h, nil
+}
+
+// Calculate returns a perceptual image hash.
+func (hh HOGHash) Calculate(img image.Image) (hashtype.Hash, error) {
+	r := imgproc.Resize(hh.width, hh.height, img, hh.interp.resizeType())
+	g, err := imgproc.Grayscale(r)
+	if err != nil {
+		return nil, err
+	}
+	bounds := g.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	mag, orient := hh.computeGradients(g, w, h)
+	return hh.computeHash(mag, orient, w, h), nil
+}
+
+// computeGradients computes gradient magnitude and unsigned orientation
+// (0–180°) for each pixel using central differences.
+func (hh HOGHash) computeGradients(img *image.Gray, w, h int) ([]float64, []float64) {
+	ox := img.Bounds().Min.X
+	oy := img.Bounds().Min.Y
+	mag := make([]float64, w*h)
+	orient := make([]float64, w*h)
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			var gx, gy float64
+			if x > 0 && x < w-1 {
+				gx = float64(img.GrayAt(x+1+ox, y+oy).Y) - float64(img.GrayAt(x-1+ox, y+oy).Y)
+			} else if x == 0 {
+				gx = float64(img.GrayAt(x+1+ox, y+oy).Y) - float64(img.GrayAt(x+ox, y+oy).Y)
+			} else {
+				gx = float64(img.GrayAt(x+ox, y+oy).Y) - float64(img.GrayAt(x-1+ox, y+oy).Y)
+			}
+			if y > 0 && y < h-1 {
+				gy = float64(img.GrayAt(x+ox, y+1+oy).Y) - float64(img.GrayAt(x+ox, y-1+oy).Y)
+			} else if y == 0 {
+				gy = float64(img.GrayAt(x+ox, y+1+oy).Y) - float64(img.GrayAt(x+ox, y+oy).Y)
+			} else {
+				gy = float64(img.GrayAt(x+ox, y+oy).Y) - float64(img.GrayAt(x+ox, y-1+oy).Y)
+			}
+			mag[y*w+x] = math.Sqrt(gx*gx + gy*gy)
+			angle := math.Atan2(gy, gx) * 180 / math.Pi
+			if angle < 0 {
+				angle += 180
+			}
+			if angle >= 180 {
+				angle = 0
+			}
+			orient[y*w+x] = angle
+		}
+	}
+	return mag, orient
+}
+
+// computeHash builds a UInt8 hash from the gradient data by computing
+// magnitude-weighted orientation histograms for each cell.
+func (hh HOGHash) computeHash(mag, orient []float64, w, h int) hashtype.UInt8 {
+	cs := int(hh.cellSize)
+	nb := int(hh.numBins)
+	cellsX := w / cs
+	cellsY := h / cs
+	if cellsX == 0 {
+		cellsX = 1
+	}
+	if cellsY == 0 {
+		cellsY = 1
+	}
+
+	binWidth := 180.0 / float64(nb)
+	hash := make(hashtype.UInt8, cellsX*cellsY*nb)
+
+	for cy := 0; cy < cellsY; cy++ {
+		for cx := 0; cx < cellsX; cx++ {
+			startX := cx * cs
+			startY := cy * cs
+			endX := startX + cs
+			endY := startY + cs
+			if endX > w {
+				endX = w
+			}
+			if endY > h {
+				endY = h
+			}
+
+			hist := make([]float64, nb)
+			for y := startY; y < endY; y++ {
+				for x := startX; x < endX; x++ {
+					idx := y*w + x
+					bin := int(orient[idx] / binWidth)
+					if bin >= nb {
+						bin = nb - 1
+					}
+					hist[bin] += mag[idx]
+				}
+			}
+
+			var maxVal float64
+			for i := range hist {
+				if hist[i] > maxVal {
+					maxVal = hist[i]
+				}
+			}
+
+			offset := (cy*cellsX + cx) * nb
+			if maxVal > 0 {
+				for i := 0; i < nb; i++ {
+					hash[offset+i] = uint8(hist[i] * 255 / maxVal)
+				}
+			}
+		}
+	}
+	return hash
+}

--- a/hoghash.go
+++ b/hoghash.go
@@ -13,7 +13,10 @@ import (
 // the image into cells, builds an orientation histogram per cell weighted
 // by gradient magnitude, and concatenates them into a single hash vector.
 //
-// See https://en.wikipedia.org/wiki/Histogram_of_oriented_gradients for more information.
+// Based on Histograms of Oriented Gradients for Human Detection;
+// Dalal and Triggs.
+//
+// See https://ieeexplore.ieee.org/document/1467360 for more information.
 type HOGHash struct {
 	// Resized image width.
 	width uint

--- a/hoghash.go
+++ b/hoghash.go
@@ -4,8 +4,8 @@ import (
 	"image"
 	"math"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // HOGHash is a perceptual hash based on Histogram of Oriented Gradients.

--- a/hoghash_test.go
+++ b/hoghash_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var hogHashCalculateTests = []struct {

--- a/hoghash_test.go
+++ b/hoghash_test.go
@@ -1,0 +1,194 @@
+package imghash_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/ajdnik/imghash"
+	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/similarity"
+)
+
+var hogHashCalculateTests = []struct {
+	filename   string
+	hash       hashtype.UInt8
+	width      uint
+	height     uint
+	resizeType Interpolation
+	cellSize   uint
+	numBins    uint
+}{
+	{"assets/lena.jpg", hashtype.UInt8{255, 11, 15, 17, 32, 10, 6, 0, 159, 255, 145, 10, 79, 90, 62, 20, 45, 136, 96, 13, 5, 56, 50, 35, 255, 92, 106, 87, 255, 250, 33, 17, 9, 61, 103, 19, 160, 21, 4, 0, 4, 0, 0, 30, 255, 86, 57, 255, 45, 125, 29, 42, 41, 18, 135, 163, 255, 135, 143, 56, 38, 75, 101, 101, 255, 98, 4, 1, 2, 2, 3, 3, 249, 47, 43, 3, 3, 4, 2, 21, 255, 114, 255, 97, 77, 62, 0, 51, 130, 117, 186, 255, 10, 31, 18, 14, 6, 107, 92, 213, 255, 158, 59, 99, 0, 5, 25, 62, 255, 55, 11, 17, 3, 23, 7, 11, 121, 153, 255, 50, 12, 5, 3, 9, 102, 111, 115, 4, 13, 2, 5, 60, 231, 245, 254, 119, 255, 193, 17, 41, 30, 0, 33, 76}, 32, 32, Bilinear, 8, 9},
+	{"assets/baboon.jpg", hashtype.UInt8{255, 116, 96, 53, 101, 61, 75, 156, 81, 80, 79, 255, 207, 249, 162, 204, 67, 51, 19, 45, 178, 130, 255, 26, 87, 150, 39, 255, 63, 94, 0, 57, 49, 49, 64, 174, 85, 49, 17, 101, 31, 94, 151, 255, 64, 255, 108, 66, 14, 6, 2, 0, 39, 167, 255, 47, 5, 0, 4, 0, 62, 72, 199, 99, 251, 255, 150, 30, 28, 16, 115, 76, 171, 43, 34, 69, 63, 55, 84, 76, 255, 76, 37, 9, 23, 22, 47, 32, 149, 254, 255, 209, 58, 54, 58, 16, 32, 90, 60, 68, 110, 46, 255, 76, 168, 142, 143, 74, 254, 103, 46, 34, 100, 49, 193, 163, 223, 52, 18, 5, 40, 81, 193, 255, 146, 71, 48, 64, 86, 255, 98, 32, 16, 21, 0, 67, 73, 255, 127, 75, 31, 38, 53, 75}, 32, 32, Bilinear, 8, 9},
+	{"assets/cat.jpg", hashtype.UInt8{42, 41, 55, 40, 188, 216, 236, 255, 65, 255, 47, 80, 5, 111, 116, 123, 105, 66, 98, 47, 254, 131, 82, 86, 100, 45, 47, 214, 151, 131, 255, 205, 154, 196, 227, 67, 84, 216, 255, 221, 186, 170, 73, 89, 57, 51, 60, 161, 255, 71, 30, 63, 0, 71, 43, 46, 150, 193, 255, 29, 122, 53, 56, 58, 48, 125, 112, 255, 115, 77, 100, 133, 150, 255, 169, 107, 84, 60, 87, 50, 107, 89, 199, 255, 95, 77, 29, 36, 43, 57, 2, 9, 121, 116, 226, 255, 201, 68, 31, 33, 133, 172, 255, 87, 34, 131, 62, 12, 59, 60, 68, 92, 198, 254, 212, 30, 30, 25, 18, 60, 100, 254, 78, 57, 29, 0, 94, 35, 191, 143, 255, 128, 36, 78, 63, 44, 71, 99, 255, 118, 63, 3, 69, 35}, 32, 32, Bilinear, 8, 9},
+	{"assets/monarch.jpg", hashtype.UInt8{255, 99, 111, 81, 41, 39, 61, 48, 245, 142, 88, 91, 109, 81, 255, 23, 116, 63, 244, 116, 89, 78, 30, 75, 143, 255, 123, 123, 28, 2, 7, 0, 7, 28, 195, 255, 73, 157, 180, 255, 32, 78, 226, 51, 85, 177, 194, 69, 123, 111, 0, 59, 195, 255, 119, 50, 96, 67, 254, 254, 114, 147, 46, 255, 193, 156, 41, 76, 93, 185, 119, 57, 84, 87, 90, 136, 72, 193, 123, 255, 198, 173, 131, 94, 38, 21, 46, 212, 255, 191, 120, 255, 208, 129, 102, 104, 75, 89, 162, 255, 236, 110, 166, 72, 43, 1, 29, 110, 182, 199, 162, 116, 141, 103, 176, 255, 118, 160, 255, 164, 154, 93, 92, 153, 210, 149, 132, 108, 100, 163, 213, 209, 139, 254, 147, 138, 198, 65, 7, 29, 3, 29, 255, 185}, 32, 32, Bilinear, 8, 9},
+	{"assets/peppers.jpg", hashtype.UInt8{73, 49, 255, 79, 90, 80, 92, 80, 40, 157, 224, 94, 115, 255, 36, 67, 93, 80, 39, 35, 83, 65, 202, 136, 255, 242, 90, 255, 192, 116, 176, 92, 48, 47, 53, 111, 255, 144, 55, 81, 141, 72, 38, 88, 52, 255, 115, 81, 26, 75, 47, 65, 61, 175, 144, 191, 126, 114, 104, 115, 198, 106, 255, 193, 118, 82, 81, 106, 243, 139, 157, 254, 255, 35, 2, 14, 18, 12, 21, 15, 22, 254, 198, 23, 38, 17, 67, 28, 124, 139, 189, 151, 135, 174, 28, 48, 157, 255, 179, 255, 70, 8, 37, 53, 33, 13, 12, 123, 169, 77, 62, 16, 255, 154, 82, 95, 201, 188, 80, 5, 0, 91, 255, 145, 106, 117, 59, 65, 166, 126, 140, 143, 254, 67, 34, 246, 93, 56, 30, 188, 255, 145, 24, 82}, 32, 32, Bilinear, 8, 9},
+	{"assets/tulips.jpg", hashtype.UInt8{101, 255, 244, 176, 52, 120, 46, 76, 148, 212, 134, 255, 100, 37, 53, 53, 94, 111, 99, 97, 70, 72, 89, 249, 105, 255, 142, 205, 81, 53, 100, 76, 238, 226, 254, 67, 111, 127, 201, 94, 36, 95, 255, 155, 105, 181, 105, 12, 156, 254, 77, 104, 111, 163, 120, 77, 78, 25, 43, 60, 104, 255, 211, 155, 126, 224, 79, 243, 146, 255, 99, 96, 183, 255, 147, 79, 93, 82, 146, 231, 118, 205, 255, 116, 76, 107, 105, 236, 165, 162, 255, 210, 148, 196, 59, 222, 131, 101, 144, 166, 97, 117, 255, 135, 105, 66, 45, 87, 117, 103, 43, 200, 255, 108, 215, 96, 18, 255, 167, 117, 123, 38, 40, 164, 127, 128, 255, 54, 159, 148, 75, 58, 43, 220, 95, 175, 21, 13, 31, 14, 14, 11, 136, 255}, 32, 32, Bilinear, 8, 9},
+}
+
+func TestHOGHash_Calculate(t *testing.T) {
+	for _, tt := range hogHashCalculateTests {
+		t.Run(tt.filename, func(t *testing.T) {
+			hash, err := NewHOGHash(WithSize(tt.width, tt.height), WithInterpolation(tt.resizeType), WithCellSize(tt.cellSize), WithNumBins(tt.numBins))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img, err := OpenImage(tt.filename)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.filename, err)
+			}
+			result, err := hash.Calculate(img)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			res := result.(hashtype.UInt8)
+			if !res.Equal(tt.hash) {
+				t.Errorf("got %v, want %v", res, tt.hash)
+			}
+		})
+	}
+}
+
+func ExampleHOGHash_Calculate() {
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		panic(err)
+	}
+	hog, err := NewHOGHash(WithSize(32, 32))
+	if err != nil {
+		panic(err)
+	}
+	hash, err := hog.Calculate(img)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hash)
+	// Output: [42 41 55 40 188 216 236 255 65 255 47 80 5 111 116 123 105 66 98 47 254 131 82 86 100 45 47 214 151 131 255 205 154 196 227 67 84 216 255 221 186 170 73 89 57 51 60 161 255 71 30 63 0 71 43 46 150 193 255 29 122 53 56 58 48 125 112 255 115 77 100 133 150 255 169 107 84 60 87 50 107 89 199 255 95 77 29 36 43 57 2 9 121 116 226 255 201 68 31 33 133 172 255 87 34 131 62 12 59 60 68 92 198 254 212 30 30 25 18 60 100 254 78 57 29 0 94 35 191 143 255 128 36 78 63 44 71 99 255 118 63 3 69 35]
+}
+
+var hogHashDistanceTests = []struct {
+	firstImage  string
+	secondImage string
+	distance    similarity.Distance
+	width       uint
+	height      uint
+	resizeType  Interpolation
+	cellSize    uint
+	numBins     uint
+}{
+	{"assets/lena.jpg", "assets/cat.jpg", 1530.9330488300263, 32, 32, Bilinear, 8, 9},
+	{"assets/lena.jpg", "assets/monarch.jpg", 1315.5991030705366, 32, 32, Bilinear, 8, 9},
+	{"assets/baboon.jpg", "assets/cat.jpg", 1403.76386903211, 32, 32, Bilinear, 8, 9},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 1183.0942481476275, 32, 32, Bilinear, 8, 9},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 1056.4710123803682, 32, 32, Bilinear, 8, 9},
+}
+
+func TestHOGHash_Distance(t *testing.T) {
+	for _, tt := range hogHashDistanceTests {
+		t.Run(fmt.Sprintf("%v %v", tt.firstImage, tt.secondImage), func(t *testing.T) {
+			hash, err := NewHOGHash(WithSize(tt.width, tt.height), WithInterpolation(tt.resizeType), WithCellSize(tt.cellSize), WithNumBins(tt.numBins))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img1, err := OpenImage(tt.firstImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.firstImage, err)
+			}
+			img2, err := OpenImage(tt.secondImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.secondImage, err)
+			}
+			h1, err := hash.Calculate(img1)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.firstImage, err)
+			}
+			h2, err := hash.Calculate(img2)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
+			}
+			dist := similarity.L2(h1, h2)
+			if !dist.Equal(tt.distance) {
+				t.Errorf("got %v, want %v", dist, tt.distance)
+			}
+		})
+	}
+}
+
+func TestNewHOGHash_defaults(t *testing.T) {
+	hog, err := NewHOGHash()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	h, err := hog.Calculate(img)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 256/8 = 32 cells per axis, 32*32*9 = 9216
+	if h.Len() != 9216 {
+		t.Errorf("expected hash length 9216, got %d", h.Len())
+	}
+}
+
+func TestNewHOGHash_invalidSize(t *testing.T) {
+	_, err := NewHOGHash(WithSize(0, 0))
+	if err != ErrInvalidSize {
+		t.Errorf("expected ErrInvalidSize, got %v", err)
+	}
+}
+
+func TestNewHOGHash_invalidCellSize(t *testing.T) {
+	_, err := NewHOGHash(WithCellSize(0))
+	if err != ErrInvalidCellSize {
+		t.Errorf("expected ErrInvalidCellSize, got %v", err)
+	}
+}
+
+func TestNewHOGHash_invalidNumBins(t *testing.T) {
+	_, err := NewHOGHash(WithNumBins(0))
+	if err != ErrInvalidNumBins {
+		t.Errorf("expected ErrInvalidNumBins, got %v", err)
+	}
+}
+
+func TestNewHOGHash_customCellSize(t *testing.T) {
+	hog, err := NewHOGHash(WithSize(32, 32), WithCellSize(16))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	h, err := hog.Calculate(img)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 32/16 = 2 cells per axis, 2*2*9 = 36
+	if h.Len() != 36 {
+		t.Errorf("expected hash length 36, got %d", h.Len())
+	}
+}
+
+func TestNewHOGHash_customNumBins(t *testing.T) {
+	hog, err := NewHOGHash(WithSize(32, 32), WithNumBins(18))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	h, err := hog.Calculate(img)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// 32/8 = 4 cells per axis, 4*4*18 = 288
+	if h.Len() != 288 {
+		t.Errorf("expected hash length 288, got %d", h.Len())
+	}
+}

--- a/imghash.go
+++ b/imghash.go
@@ -11,7 +11,7 @@ import (
 // Hasher computes a perceptual hash from an image.
 // It is implemented by all hash algorithms in this package:
 // Average, Difference, PHash, Median, BlockMean, MarrHildreth,
-// RadialVariance, ColorMoment, WHash, and LBP.
+// RadialVariance, ColorMoment, WHash, LBP, and HOGHash.
 type Hasher interface {
 	Calculate(image.Image) (hashtype.Hash, error)
 }
@@ -57,4 +57,8 @@ var (
 	ErrInvalidLevel = errors.New("imghash: level must be greater than zero")
 	// ErrInvalidGridSize is returned when grid width or height is zero.
 	ErrInvalidGridSize = errors.New("imghash: grid size dimensions must be greater than zero")
+	// ErrInvalidCellSize is returned when the cell size is zero.
+	ErrInvalidCellSize = errors.New("imghash: cell size must be greater than zero")
+	// ErrInvalidNumBins is returned when the number of histogram bins is zero.
+	ErrInvalidNumBins = errors.New("imghash: number of bins must be greater than zero")
 )

--- a/imghash.go
+++ b/imghash.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"image"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // Hasher computes a perceptual hash from an image.

--- a/interpolation.go
+++ b/interpolation.go
@@ -1,6 +1,6 @@
 package imghash
 
-import "github.com/ajdnik/imghash/internal/imgproc"
+import "github.com/ajdnik/imghash/v2/internal/imgproc"
 
 // Interpolation specifies the resize interpolation method used during hash computation.
 type Interpolation int

--- a/interpolation_test.go
+++ b/interpolation_test.go
@@ -3,7 +3,7 @@ package imghash_test
 import (
 	"testing"
 
-	. "github.com/ajdnik/imghash"
+	. "github.com/ajdnik/imghash/v2"
 )
 
 func TestInterpolation_String(t *testing.T) {

--- a/lbp.go
+++ b/lbp.go
@@ -3,8 +3,8 @@ package imghash
 import (
 	"image"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // LBP is a perceptual hash based on Local Binary Patterns.

--- a/lbp.go
+++ b/lbp.go
@@ -12,7 +12,10 @@ import (
 // a grid of cells, builds a 256-bin histogram per cell, and concatenates
 // them into a single hash vector.
 //
-// See https://en.wikipedia.org/wiki/Local_binary_patterns for more information.
+// Based on Multiresolution Gray-Scale and Rotation Invariant Texture
+// Classification with Local Binary Patterns; Ojala et. al.
+//
+// See https://ieeexplore.ieee.org/document/1017623 for more information.
 type LBP struct {
 	// Resized image width.
 	width uint

--- a/lbp_test.go
+++ b/lbp_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var lbpCalculateTests = []struct {

--- a/marrhildreth.go
+++ b/marrhildreth.go
@@ -4,8 +4,8 @@ import (
 	"image"
 	"math"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 const (

--- a/marrhildreth_test.go
+++ b/marrhildreth_test.go
@@ -5,9 +5,9 @@ import (
 
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var marrHildrethCalculateTests = []struct {

--- a/medianhash.go
+++ b/medianhash.go
@@ -4,8 +4,8 @@ import (
 	"image"
 	"math"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // Median is a perceptual hash that uses a similar approach as Average hash.

--- a/medianhash_test.go
+++ b/medianhash_test.go
@@ -7,9 +7,9 @@ import (
 	_ "image/png"
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var medianCalculateTests = []struct {

--- a/options.go
+++ b/options.go
@@ -33,6 +33,9 @@ type WHashOption interface{ applyWHash(*WHash) }
 // LBPOption configures the LBP hash algorithm.
 type LBPOption interface{ applyLBP(*LBP) }
 
+// HOGHashOption configures the HOGHash algorithm.
+type HOGHashOption interface{ applyHOGHash(*HOGHash) }
+
 // --- concrete option types ---
 
 type sizeOption struct{ width, height uint }
@@ -46,6 +49,7 @@ func (o sizeOption) applyMarrHildreth(m *MarrHildreth) { m.width, m.height = o.w
 func (o sizeOption) applyColorMoment(c *ColorMoment)   { c.width, c.height = o.width, o.height }
 func (o sizeOption) applyWHash(w *WHash)               { w.width, w.height = o.width, o.height }
 func (o sizeOption) applyLBP(l *LBP)                   { l.width, l.height = o.width, o.height }
+func (o sizeOption) applyHOGHash(h *HOGHash)           { h.width, h.height = o.width, o.height }
 
 type interpolationOption struct{ interp Interpolation }
 
@@ -58,6 +62,7 @@ func (o interpolationOption) applyMarrHildreth(m *MarrHildreth) { m.interp = o.i
 func (o interpolationOption) applyColorMoment(c *ColorMoment)   { c.interp = o.interp }
 func (o interpolationOption) applyWHash(w *WHash)               { w.interp = o.interp }
 func (o interpolationOption) applyLBP(l *LBP)                   { l.interp = o.interp }
+func (o interpolationOption) applyHOGHash(h *HOGHash)           { h.interp = o.interp }
 
 type kernelSizeOption struct{ size int }
 
@@ -98,16 +103,24 @@ type gridSizeOption struct{ x, y uint }
 
 func (o gridSizeOption) applyLBP(l *LBP) { l.gridX, l.gridY = o.x, o.y }
 
+type cellSizeOption struct{ size uint }
+
+func (o cellSizeOption) applyHOGHash(h *HOGHash) { h.cellSize = o.size }
+
+type numBinsOption struct{ bins uint }
+
+func (o numBinsOption) applyHOGHash(h *HOGHash) { h.numBins = o.bins }
+
 // --- public constructors ---
 
 // WithSize sets the resize dimensions used during hash computation.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, and LBP.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, and HOGHash.
 func WithSize(width, height uint) sizeOption {
 	return sizeOption{width, height}
 }
 
 // WithInterpolation sets the resize interpolation method.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, and LBP.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, and HOGHash.
 func WithInterpolation(interp Interpolation) interpolationOption {
 	return interpolationOption{interp}
 }
@@ -165,4 +178,16 @@ func WithLevel(level int) levelOption {
 // Applies to LBP.
 func WithGridSize(x, y uint) gridSizeOption {
 	return gridSizeOption{x, y}
+}
+
+// WithCellSize sets the cell size in pixels (square cells) for HOG computation.
+// Applies to HOGHash.
+func WithCellSize(size uint) cellSizeOption {
+	return cellSizeOption{size}
+}
+
+// WithNumBins sets the number of orientation histogram bins.
+// Applies to HOGHash.
+func WithNumBins(bins uint) numBinsOption {
+	return numBinsOption{bins}
 }

--- a/options_typecheck_test.go
+++ b/options_typecheck_test.go
@@ -43,3 +43,8 @@ var _ WHashOption = WithLevel(0)
 var _ LBPOption = WithSize(0, 0)
 var _ LBPOption = WithInterpolation(Bilinear)
 var _ LBPOption = WithGridSize(0, 0)
+
+var _ HOGHashOption = WithSize(0, 0)
+var _ HOGHashOption = WithInterpolation(Bilinear)
+var _ HOGHashOption = WithCellSize(0)
+var _ HOGHashOption = WithNumBins(0)

--- a/phash.go
+++ b/phash.go
@@ -3,8 +3,8 @@ package imghash
 import (
 	"image"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // Size of the low-frequency DCT coefficient block used by PHash.

--- a/phash_test.go
+++ b/phash_test.go
@@ -5,9 +5,9 @@ import (
 
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var pHashCalculateTests = []struct {

--- a/radialvariance.go
+++ b/radialvariance.go
@@ -4,8 +4,8 @@ import (
 	"image"
 	"math"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // RadialVariance is a perceptual hash that uses the method described in

--- a/radialvariance_test.go
+++ b/radialvariance_test.go
@@ -6,9 +6,9 @@ import (
 
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var radialVarianceCalculateTests = []struct {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,8 @@
   "packages": {
     ".": {
       "release-type": "go",
-      "package-name": "imghash"
+      "package-name": "imghash",
+      "include-component-in-tag": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"

--- a/similarity/distance_test.go
+++ b/similarity/distance_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2/similarity"
 )
 
 var distanceEqualTests = []struct {

--- a/similarity/hamming.go
+++ b/similarity/hamming.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"math/bits"
 
-	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/v2/hashtype"
 )
 
 // ErrNotBinaryHash is reported when a non-binary hash is passed to Hamming.

--- a/similarity/hamming_test.go
+++ b/similarity/hamming_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ajdnik/imghash/hashtype"
-	. "github.com/ajdnik/imghash/similarity"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	. "github.com/ajdnik/imghash/v2/similarity"
 )
 
 var hammingTests = []struct {

--- a/similarity/l2.go
+++ b/similarity/l2.go
@@ -3,7 +3,7 @@ package similarity
 import (
 	"math"
 
-	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/v2/hashtype"
 )
 
 // L2 calculates the L2 (Euclidean) distance between two hashes.

--- a/similarity/l2_test.go
+++ b/similarity/l2_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ajdnik/imghash/hashtype"
-	. "github.com/ajdnik/imghash/similarity"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	. "github.com/ajdnik/imghash/v2/similarity"
 )
 
 var l2Float64Tests = []struct {

--- a/similarity/pcc.go
+++ b/similarity/pcc.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"math"
 
-	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/v2/hashtype"
 )
 
 // ErrNotSameLength is reported when the length of hashes doesn't match.

--- a/similarity/pcc_test.go
+++ b/similarity/pcc_test.go
@@ -3,8 +3,8 @@ package similarity_test
 import (
 	"fmt"
 
-	"github.com/ajdnik/imghash/hashtype"
-	. "github.com/ajdnik/imghash/similarity"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	. "github.com/ajdnik/imghash/v2/similarity"
 
 	"testing"
 )

--- a/threshold.go
+++ b/threshold.go
@@ -3,7 +3,7 @@ package imghash
 import (
 	"image"
 
-	"github.com/ajdnik/imghash/hashtype"
+	"github.com/ajdnik/imghash/v2/hashtype"
 )
 
 // thresholdHash builds a binary hash by setting a bit for every pixel

--- a/wavelet.go
+++ b/wavelet.go
@@ -4,8 +4,8 @@ import (
 	"image"
 	"sort"
 
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
 )
 
 // WHash is a perceptual hash based on the Haar wavelet transform.

--- a/wavelet_test.go
+++ b/wavelet_test.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/ajdnik/imghash"
-	"github.com/ajdnik/imghash/hashtype"
-	"github.com/ajdnik/imghash/similarity"
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 var wHashCalculateTests = []struct {


### PR DESCRIPTION
## Summary

- Add a new **HOG Hash** (Histogram of Oriented Gradients) perceptual hashing algorithm that computes gradient-based orientation histograms per cell and concatenates them into a uint8 hash vector
- Wire up configurable options (`WithSize`, `WithInterpolation`, `WithCellSize`, `WithNumBins`) following the existing functional options pattern
- Include full test coverage (hash calculation, L2 distance, validation, examples) and update README documentation

## Type of Change

- [x] `feat` (new feature)

## Validation

All tests pass locally:

```bash
go test ./...
go vet ./...
```

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).