### PR TITLE
feat: Facebook PDQ Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ You can also call `h1.Distance(h2)` directly on any hash value.
 
 ## Perceptual Hash Algorithms
 
-The library supports 11 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
+The library supports 12 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
 
 Every constructor accepts functional options. Call with no arguments for defaults, or pass `With*` options to customize:
 
@@ -267,6 +267,21 @@ hash, err := rv.Calculate(img)
 |--------|---------|
 | `WithSigma(s)` | 1 |
 | `WithAngles(n)` | 180 |
+
+#### PDQ Hash
+
+Produces a 256-bit binary hash designed for large-scale image deduplication. The algorithm resizes to 64×64, applies a Jarosz box filter for noise smoothing, computes a 2D DCT, and thresholds the 16×16 low-frequency coefficients against their median. Robust to JPEG compression, rescaling, and minor edits. From Facebook (Meta) [ThreatExchange PDQ](https://github.com/facebook/ThreatExchange/tree/main/pdq).
+
+```go
+pdq, err := imghash.NewPDQ()
+hash, err := pdq.Calculate(img)
+```
+
+| Option | Default |
+|--------|---------|
+| `WithInterpolation(i)` | `Bilinear` |
+
+The input size is fixed at 64×64 per the algorithm specification and is not configurable.
 
 ## Similarity Metrics
 

--- a/imghash.go
+++ b/imghash.go
@@ -11,7 +11,7 @@ import (
 // Hasher computes a perceptual hash from an image.
 // It is implemented by all hash algorithms in this package:
 // Average, Difference, PHash, Median, BlockMean, MarrHildreth,
-// RadialVariance, ColorMoment, WHash, LBP, and HOGHash.
+// RadialVariance, ColorMoment, WHash, LBP, HOGHash, and PDQ.
 type Hasher interface {
 	Calculate(image.Image) (hashtype.Hash, error)
 }

--- a/internal/imgproc/jarosz.go
+++ b/internal/imgproc/jarosz.go
@@ -1,0 +1,71 @@
+package imgproc
+
+// JaroszFilter applies a Jarosz box filter to a float32 matrix.
+// The filter is an iterative 1-D box average applied first along rows
+// then along columns, each direction repeated nreps times.
+// windowSize is the half-width of the box kernel; the full kernel width
+// is 2*windowSize+1.
+func JaroszFilter(buf [][]float32, windowSize, nreps int) {
+	if len(buf) == 0 || len(buf[0]) == 0 {
+		return
+	}
+	rows := len(buf)
+	cols := len(buf[0])
+	for i := 0; i < nreps; i++ {
+		boxAlongRows(buf, rows, cols, windowSize)
+	}
+	for i := 0; i < nreps; i++ {
+		boxAlongCols(buf, rows, cols, windowSize)
+	}
+}
+
+func boxAlongRows(buf [][]float32, rows, cols, windowSize int) {
+	w := float32(2*windowSize + 1)
+	for i := 0; i < rows; i++ {
+		row := buf[i]
+		s := row[0] * float32(windowSize)
+		for j := 1; j <= windowSize && j < cols; j++ {
+			s += row[j]
+		}
+		s += row[0]
+		row[0] = s / w
+		for j := 1; j < cols; j++ {
+			jn := j + windowSize
+			jp := j - windowSize - 1
+			var lead, trail float32
+			if jn < cols {
+				lead = row[jn]
+			}
+			if jp >= 0 {
+				trail = row[jp]
+			}
+			s += lead - trail
+			row[j] = s / w
+		}
+	}
+}
+
+func boxAlongCols(buf [][]float32, rows, cols, windowSize int) {
+	w := float32(2*windowSize + 1)
+	for j := 0; j < cols; j++ {
+		s := buf[0][j] * float32(windowSize)
+		for i := 1; i <= windowSize && i < rows; i++ {
+			s += buf[i][j]
+		}
+		s += buf[0][j]
+		buf[0][j] = s / w
+		for i := 1; i < rows; i++ {
+			in := i + windowSize
+			ip := i - windowSize - 1
+			var lead, trail float32
+			if in < rows {
+				lead = buf[in][j]
+			}
+			if ip >= 0 {
+				trail = buf[ip][j]
+			}
+			s += lead - trail
+			buf[i][j] = s / w
+		}
+	}
+}

--- a/options.go
+++ b/options.go
@@ -36,6 +36,9 @@ type LBPOption interface{ applyLBP(*LBP) }
 // HOGHashOption configures the HOGHash algorithm.
 type HOGHashOption interface{ applyHOGHash(*HOGHash) }
 
+// PDQOption configures the PDQ hash algorithm.
+type PDQOption interface{ applyPDQ(*PDQ) }
+
 // --- concrete option types ---
 
 type sizeOption struct{ width, height uint }
@@ -63,6 +66,7 @@ func (o interpolationOption) applyColorMoment(c *ColorMoment)   { c.interp = o.i
 func (o interpolationOption) applyWHash(w *WHash)               { w.interp = o.interp }
 func (o interpolationOption) applyLBP(l *LBP)                   { l.interp = o.interp }
 func (o interpolationOption) applyHOGHash(h *HOGHash)           { h.interp = o.interp }
+func (o interpolationOption) applyPDQ(p *PDQ)                   { p.interp = o.interp }
 
 type kernelSizeOption struct{ size int }
 
@@ -120,7 +124,7 @@ func WithSize(width, height uint) sizeOption {
 }
 
 // WithInterpolation sets the resize interpolation method.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, and HOGHash.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, HOGHash, and PDQ.
 func WithInterpolation(interp Interpolation) interpolationOption {
 	return interpolationOption{interp}
 }

--- a/options_typecheck_test.go
+++ b/options_typecheck_test.go
@@ -48,3 +48,5 @@ var _ HOGHashOption = WithSize(0, 0)
 var _ HOGHashOption = WithInterpolation(Bilinear)
 var _ HOGHashOption = WithCellSize(0)
 var _ HOGHashOption = WithNumBins(0)
+
+var _ PDQOption = WithInterpolation(Bilinear)

--- a/pdq.go
+++ b/pdq.go
@@ -1,0 +1,102 @@
+package imghash
+
+import (
+	"image"
+	"sort"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
+)
+
+// pdqDCTSize is the dimension of the DCT input buffer.
+const pdqDCTSize = 64
+
+// pdqCoefSize is the dimension of the DCT coefficient block used for hashing.
+// A 16x16 block produces a 256-bit (32-byte) binary hash.
+const pdqCoefSize = 16
+
+// pdqHashBytes is the number of bytes in the resulting hash.
+const pdqHashBytes = pdqCoefSize * pdqCoefSize / 8
+
+// pdqJaroszWindow is the half-width of the Jarosz box filter kernel.
+const pdqJaroszWindow = 2
+
+// pdqJaroszReps is the number of Jarosz filter iterations per axis.
+const pdqJaroszReps = 2
+
+// PDQ is a perceptual hash that uses the method described in
+// PDQ and TMK+PDQF by Facebook (now Meta).
+// It produces a 256-bit hash robust to JPEG compression, rescaling,
+// and minor edits while remaining fast enough for large-scale deduplication.
+//
+// See https://github.com/facebook/ThreatExchange/tree/main/pdq for more information.
+type PDQ struct {
+	// Resize interpolation method.
+	interp Interpolation
+}
+
+// NewPDQ creates a new PDQ hasher with the given options.
+// Without options, sensible defaults are used.
+func NewPDQ(opts ...PDQOption) (PDQ, error) {
+	p := PDQ{
+		interp: Bilinear,
+	}
+	for _, o := range opts {
+		o.applyPDQ(&p)
+	}
+	return p, nil
+}
+
+// Calculate returns a 256-bit perceptual hash of the image.
+func (p PDQ) Calculate(img image.Image) (hashtype.Hash, error) {
+	r := imgproc.Resize(pdqDCTSize, pdqDCTSize, img, p.interp.resizeType())
+	g, err := imgproc.Grayscale(r)
+	if err != nil {
+		return nil, err
+	}
+	buf := imgproc.GrayToF32(g)
+	imgproc.JaroszFilter(buf, pdqJaroszWindow, pdqJaroszReps)
+	dct := imgproc.DCT(buf)
+	block := p.extractBlock(dct)
+	med := p.median(block)
+	return p.computeHash(block, med), nil
+}
+
+// extractBlock returns the top-left pdqCoefSize x pdqCoefSize block from the DCT output.
+func (p PDQ) extractBlock(dct [][]float32) [][]float32 {
+	block := make([][]float32, pdqCoefSize)
+	for i := 0; i < pdqCoefSize; i++ {
+		block[i] = make([]float32, pdqCoefSize)
+		copy(block[i], dct[i][:pdqCoefSize])
+	}
+	return block
+}
+
+// median computes the median of all values in the block.
+func (p PDQ) median(block [][]float32) float32 {
+	n := len(block) * len(block[0])
+	vals := make([]float32, 0, n)
+	for _, row := range block {
+		vals = append(vals, row...)
+	}
+	sort.Slice(vals, func(i, j int) bool { return vals[i] < vals[j] })
+	if n%2 == 0 {
+		return (vals[n/2-1] + vals[n/2]) / 2
+	}
+	return vals[n/2]
+}
+
+// computeHash thresholds the DCT block against the median to produce a 256-bit hash.
+func (p PDQ) computeHash(block [][]float32, median float32) hashtype.Binary {
+	hash := make(hashtype.Binary, pdqHashBytes)
+	var c uint
+	for i := range block {
+		for j := range block[i] {
+			if block[i][j] > median {
+				_ = hash.Set(c)
+			}
+			c++
+		}
+	}
+	return hash
+}

--- a/pdq_test.go
+++ b/pdq_test.go
@@ -1,0 +1,111 @@
+package imghash_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
+)
+
+var pdqCalculateTests = []struct {
+	filename   string
+	hash       hashtype.Binary
+	resizeType Interpolation
+}{
+	{"assets/lena.jpg", hashtype.Binary{191, 0, 123, 5, 107, 81, 181, 32, 255, 82, 205, 10, 101, 173, 121, 166, 146, 229, 208, 180, 210, 252, 0, 219, 64, 127, 24, 219, 0, 253, 88, 125}, Bilinear},
+	{"assets/baboon.jpg", hashtype.Binary{255, 0, 5, 234, 7, 169, 191, 1, 225, 248, 133, 43, 17, 108, 251, 128, 16, 127, 131, 39, 0, 255, 234, 85, 64, 255, 226, 221, 64, 255, 106, 85}, Bilinear},
+	{"assets/cat.jpg", hashtype.Binary{255, 0, 255, 0, 233, 42, 61, 168, 171, 5, 179, 17, 119, 2, 85, 174, 152, 255, 140, 217, 96, 247, 72, 93, 0, 253, 2, 119, 4, 255, 0, 255}, Bilinear},
+	{"assets/monarch.jpg", hashtype.Binary{191, 0, 255, 1, 38, 136, 63, 0, 153, 247, 237, 41, 128, 240, 71, 2, 198, 93, 128, 253, 104, 245, 0, 255, 64, 255, 0, 255, 64, 255, 224, 255}, Bilinear},
+	{"assets/peppers.jpg", hashtype.Binary{239, 1, 253, 144, 63, 0, 9, 229, 227, 8, 131, 218, 131, 218, 187, 87, 192, 246, 148, 10, 80, 255, 6, 255, 0, 253, 38, 109, 24, 255, 118, 36}, Bilinear},
+	{"assets/tulips.jpg", hashtype.Binary{171, 0, 127, 0, 126, 4, 127, 8, 63, 8, 123, 16, 52, 120, 165, 11, 160, 251, 47, 95, 200, 55, 202, 53, 128, 247, 128, 253, 212, 255, 192, 247}, Bilinear},
+}
+
+func TestPDQ_Calculate(t *testing.T) {
+	for _, tt := range pdqCalculateTests {
+		t.Run(tt.filename, func(t *testing.T) {
+			hash, err := NewPDQ(WithInterpolation(tt.resizeType))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img, err := OpenImage(tt.filename)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.filename, err)
+			}
+			result, err := hash.Calculate(img)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			res := result.(hashtype.Binary)
+			if !res.Equal(tt.hash) {
+				t.Errorf("got %v, want %v", res, tt.hash)
+			}
+		})
+	}
+}
+
+func ExamplePDQ_Calculate() {
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		panic(err)
+	}
+	pdq, err := NewPDQ()
+	if err != nil {
+		panic(err)
+	}
+	hash, err := pdq.Calculate(img)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hash)
+	// Output: [255 0 255 0 233 42 61 168 171 5 179 17 119 2 85 174 152 255 140 217 96 247 72 93 0 253 2 119 4 255 0 255]
+}
+
+var pdqDistanceTests = []struct {
+	firstImage  string
+	secondImage string
+	distance    similarity.Distance
+	resizeType  Interpolation
+}{
+	{"assets/lena.jpg", "assets/cat.jpg", 90, Bilinear},
+	{"assets/lena.jpg", "assets/monarch.jpg", 80, Bilinear},
+	{"assets/baboon.jpg", "assets/cat.jpg", 102, Bilinear},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 98, Bilinear},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 84, Bilinear},
+}
+
+func TestPDQ_Distance(t *testing.T) {
+	for _, tt := range pdqDistanceTests {
+		t.Run(fmt.Sprintf("%v %v", tt.firstImage, tt.secondImage), func(t *testing.T) {
+			hash, err := NewPDQ(WithInterpolation(tt.resizeType))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img1, err := OpenImage(tt.firstImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.firstImage, err)
+			}
+			img2, err := OpenImage(tt.secondImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.secondImage, err)
+			}
+			h1, err := hash.Calculate(img1)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.firstImage, err)
+			}
+			h2, err := hash.Calculate(img2)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
+			}
+			dist, err := similarity.Hamming(h1, h2)
+			if err != nil {
+				t.Fatalf("failed to compute distance: %v", err)
+			}
+			if !dist.Equal(tt.distance) {
+				t.Errorf("got %v, want %v", dist, tt.distance)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add the Facebook PDQ (Perceptual Distance Quantization) perceptual hashing algorithm
- PDQ produces a 256-bit binary hash robust to JPEG compression, rescaling, and minor edits, designed for large-scale image deduplication
- The algorithm resizes to 64×64, applies a Jarosz box filter, computes a 2D DCT, and thresholds the 16×16 low-frequency coefficients against their median

## Type of Change

- [x] `feat` (new feature)

## Validation

```bash
go test ./... -count=1
```

All 4 packages pass, including new `TestPDQ_Calculate` (6 images) and `TestPDQ_Distance` (5 image pairs) plus an `ExamplePDQ_Calculate` test.

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## New Files

| File | Purpose |
|------|---------|
| `pdq.go` | `PDQ` struct, `NewPDQ` constructor, `Calculate` method |
| `pdq_test.go` | Hash and distance regression tests |
| `internal/imgproc/jarosz.go` | Jarosz iterative box filter |

## Modified Files

| File | Change |
|------|--------|
| `imghash.go` | List PDQ in `Hasher` doc comment |
| `options.go` | Add `PDQOption` interface, wire `WithInterpolation` |
| `options_typecheck_test.go` | Compile-time assertion for `PDQOption` |
| `README.md` | Add PDQ section, update algorithm count to 12 |