### PR TITLE
feat: Rotation Aware Hash

### DIFF
--- a/imghash.go
+++ b/imghash.go
@@ -11,7 +11,7 @@ import (
 // Hasher computes a perceptual hash from an image.
 // It is implemented by all hash algorithms in this package:
 // Average, Difference, PHash, Median, BlockMean, MarrHildreth,
-// RadialVariance, ColorMoment, WHash, LBP, HOGHash, and PDQ.
+// RadialVariance, ColorMoment, WHash, LBP, HOGHash, PDQ, and RASH.
 type Hasher interface {
 	Calculate(image.Image) (hashtype.Hash, error)
 }
@@ -61,4 +61,6 @@ var (
 	ErrInvalidCellSize = errors.New("imghash: cell size must be greater than zero")
 	// ErrInvalidNumBins is returned when the number of histogram bins is zero.
 	ErrInvalidNumBins = errors.New("imghash: number of bins must be greater than zero")
+	// ErrInvalidRings is returned when the number of concentric rings is not positive.
+	ErrInvalidRings = errors.New("imghash: rings must be greater than zero")
 )

--- a/options.go
+++ b/options.go
@@ -39,6 +39,9 @@ type HOGHashOption interface{ applyHOGHash(*HOGHash) }
 // PDQOption configures the PDQ hash algorithm.
 type PDQOption interface{ applyPDQ(*PDQ) }
 
+// RASHOption configures the RASH hash algorithm.
+type RASHOption interface{ applyRASH(*RASH) }
+
 // --- concrete option types ---
 
 type sizeOption struct{ width, height uint }
@@ -53,6 +56,7 @@ func (o sizeOption) applyColorMoment(c *ColorMoment)   { c.width, c.height = o.w
 func (o sizeOption) applyWHash(w *WHash)               { w.width, w.height = o.width, o.height }
 func (o sizeOption) applyLBP(l *LBP)                   { l.width, l.height = o.width, o.height }
 func (o sizeOption) applyHOGHash(h *HOGHash)           { h.width, h.height = o.width, o.height }
+func (o sizeOption) applyRASH(r *RASH)                 { r.width, r.height = o.width, o.height }
 
 type interpolationOption struct{ interp Interpolation }
 
@@ -67,6 +71,7 @@ func (o interpolationOption) applyWHash(w *WHash)               { w.interp = o.i
 func (o interpolationOption) applyLBP(l *LBP)                   { l.interp = o.interp }
 func (o interpolationOption) applyHOGHash(h *HOGHash)           { h.interp = o.interp }
 func (o interpolationOption) applyPDQ(p *PDQ)                   { p.interp = o.interp }
+func (o interpolationOption) applyRASH(r *RASH)                 { r.interp = o.interp }
 
 type kernelSizeOption struct{ size int }
 
@@ -78,6 +83,7 @@ type sigmaOption struct{ sigma float64 }
 func (o sigmaOption) applyMarrHildreth(m *MarrHildreth)     { m.sigma = o.sigma }
 func (o sigmaOption) applyColorMoment(c *ColorMoment)       { c.sigma = o.sigma }
 func (o sigmaOption) applyRadialVariance(r *RadialVariance) { r.sigma = o.sigma }
+func (o sigmaOption) applyRASH(r *RASH)                     { r.sigma = o.sigma }
 
 type blockSizeOption struct{ width, height uint }
 
@@ -115,16 +121,20 @@ type numBinsOption struct{ bins uint }
 
 func (o numBinsOption) applyHOGHash(h *HOGHash) { h.numBins = o.bins }
 
+type ringsOption struct{ rings int }
+
+func (o ringsOption) applyRASH(r *RASH) { r.rings = o.rings }
+
 // --- public constructors ---
 
 // WithSize sets the resize dimensions used during hash computation.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, and HOGHash.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, HOGHash, and RASH.
 func WithSize(width, height uint) sizeOption {
 	return sizeOption{width, height}
 }
 
 // WithInterpolation sets the resize interpolation method.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, HOGHash, and PDQ.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, HOGHash, PDQ, and RASH.
 func WithInterpolation(interp Interpolation) interpolationOption {
 	return interpolationOption{interp}
 }
@@ -136,7 +146,7 @@ func WithKernelSize(size int) kernelSizeOption {
 }
 
 // WithSigma sets the Gaussian kernel standard deviation.
-// Applies to MarrHildreth, ColorMoment, and RadialVariance.
+// Applies to MarrHildreth, ColorMoment, RadialVariance, and RASH.
 func WithSigma(sigma float64) sigmaOption {
 	return sigmaOption{sigma}
 }
@@ -194,4 +204,10 @@ func WithCellSize(size uint) cellSizeOption {
 // Applies to HOGHash.
 func WithNumBins(bins uint) numBinsOption {
 	return numBinsOption{bins}
+}
+
+// WithRings sets the number of concentric rings used for spatial sampling.
+// Applies to RASH.
+func WithRings(rings int) ringsOption {
+	return ringsOption{rings}
 }

--- a/options_typecheck_test.go
+++ b/options_typecheck_test.go
@@ -50,3 +50,8 @@ var _ HOGHashOption = WithCellSize(0)
 var _ HOGHashOption = WithNumBins(0)
 
 var _ PDQOption = WithInterpolation(Bilinear)
+
+var _ RASHOption = WithSize(0, 0)
+var _ RASHOption = WithInterpolation(Bilinear)
+var _ RASHOption = WithSigma(0)
+var _ RASHOption = WithRings(0)

--- a/rash.go
+++ b/rash.go
@@ -1,0 +1,142 @@
+package imghash
+
+import (
+	"image"
+	"math"
+	"sort"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
+)
+
+// RASH is a Rotation Aware Spatial Hash — a perceptual hash designed to be
+// robust against image rotation. It works by sampling pixel intensities on
+// concentric rings around the image centre, then applying a 1-D DCT to the
+// ring means and binarising the low-frequency coefficients.
+//
+// Because ring-mean features are inherently rotation-invariant (rotating the
+// image only permutes pixels within a ring, leaving its mean unchanged), the
+// resulting hash stays stable under arbitrary rotations.
+type RASH struct {
+	width  uint
+	height uint
+	interp Interpolation
+	sigma  float64
+	rings  int
+}
+
+const rashHashBits = 64
+
+// NewRASH creates a new RASH hash with the given options.
+// Without options, sensible defaults are used.
+func NewRASH(opts ...RASHOption) (RASH, error) {
+	r := RASH{
+		width:  256,
+		height: 256,
+		interp: Bilinear,
+		sigma:  1,
+		rings:  180,
+	}
+	for _, o := range opts {
+		o.applyRASH(&r)
+	}
+	if r.width == 0 || r.height == 0 {
+		return RASH{}, ErrInvalidSize
+	}
+	if r.sigma < 0 {
+		return RASH{}, ErrInvalidSigma
+	}
+	if r.rings <= 0 {
+		return RASH{}, ErrInvalidRings
+	}
+	return r, nil
+}
+
+// Calculate returns a perceptual image hash.
+func (r RASH) Calculate(img image.Image) (hashtype.Hash, error) {
+	resized := imgproc.Resize(r.width, r.height, img, r.interp.resizeType())
+	g, err := imgproc.Grayscale(resized)
+	if err != nil {
+		return nil, err
+	}
+	blurred := imgproc.GaussianBlur(g, 0, r.sigma)
+	means := r.ringMeans(blurred.(*image.Gray))
+	return r.computeHash(means), nil
+}
+
+// ringMeans computes the mean pixel intensity for each concentric ring.
+func (r RASH) ringMeans(img *image.Gray) []float64 {
+	bounds := img.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	cx, cy := float64(w)/2.0, float64(h)/2.0
+	maxRadius := cx
+	if cy < maxRadius {
+		maxRadius = cy
+	}
+
+	ringWidth := maxRadius / float64(r.rings)
+	sums := make([]float64, r.rings)
+	counts := make([]int, r.rings)
+
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			dx := float64(x) + 0.5 - cx
+			dy := float64(y) + 0.5 - cy
+			dist := math.Sqrt(dx*dx + dy*dy)
+			ring := int(dist / ringWidth)
+			if ring >= r.rings {
+				ring = r.rings - 1
+			}
+			sums[ring] += float64(img.GrayAt(x+bounds.Min.X, y+bounds.Min.Y).Y)
+			counts[ring]++
+		}
+	}
+
+	means := make([]float64, r.rings)
+	for i := 0; i < r.rings; i++ {
+		if counts[i] > 0 {
+			means[i] = sums[i] / float64(counts[i])
+		}
+	}
+	return means
+}
+
+// computeHash applies a 1-D DCT to the ring means, keeps the first
+// rashHashBits low-frequency coefficients (skipping DC), and binarises
+// them against the median.
+func (r RASH) computeHash(means []float64) hashtype.Binary {
+	n := len(means)
+	dct := make([]float64, n)
+	c0 := math.Sqrt(1.0 / float64(n))
+	c1 := math.Sqrt(2.0 / float64(n))
+	for k := 0; k < n; k++ {
+		var sum float64
+		for i := 0; i < n; i++ {
+			sum += means[i] * math.Cos(math.Pi*float64(2*i+1)*float64(k)/float64(2*n))
+		}
+		if k == 0 {
+			dct[k] = sum * c0
+		} else {
+			dct[k] = sum * c1
+		}
+	}
+
+	hashBits := rashHashBits
+	if n-1 < hashBits {
+		hashBits = n - 1
+	}
+	coeffs := dct[1 : hashBits+1]
+
+	sorted := make([]float64, len(coeffs))
+	copy(sorted, coeffs)
+	sort.Float64s(sorted)
+	median := sorted[len(sorted)/2]
+
+	hash := make(hashtype.Binary, hashBits/8)
+	for i, c := range coeffs {
+		if c > median {
+			_ = hash.Set(uint(i))
+		}
+	}
+	return hash
+}

--- a/rash.go
+++ b/rash.go
@@ -10,13 +10,17 @@ import (
 )
 
 // RASH is a Rotation Aware Spatial Hash — a perceptual hash designed to be
-// robust against image rotation. It works by sampling pixel intensities on
-// concentric rings around the image centre, then applying a 1-D DCT to the
-// ring means and binarising the low-frequency coefficients.
+// robust against image rotation. It combines concentric ring sampling for
+// rotation invariance, a 1-D DCT for frequency compaction, and median
+// thresholding for binarisation.
 //
 // Because ring-mean features are inherently rotation-invariant (rotating the
 // image only permutes pixels within a ring, leaving its mean unchanged), the
 // resulting hash stays stable under arbitrary rotations.
+//
+// Inspired by ring-partition hashing literature:
+//   - Tang et al., "Robust Image Hashing with Ring Partition and Invariant Vector Distance" (2016)
+//   - De Roover et al., "Robust image hashing based on radial variance of pixels" (2005)
 type RASH struct {
 	width  uint
 	height uint

--- a/rash_test.go
+++ b/rash_test.go
@@ -1,0 +1,141 @@
+package imghash_test
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
+)
+
+var rashCalculateTests = []struct {
+	filename   string
+	hash       hashtype.Binary
+	width      uint
+	height     uint
+	resizeType Interpolation
+	sigma      float64
+	rings      int
+}{
+	{"assets/lena.jpg", hashtype.Binary{6, 0, 99, 12, 0, 253, 255, 255}, 256, 256, Bilinear, 1, 180},
+	{"assets/baboon.jpg", hashtype.Binary{241, 27, 3, 0, 0, 240, 255, 255}, 256, 256, Bilinear, 1, 180},
+	{"assets/cat.jpg", hashtype.Binary{46, 0, 64, 32, 128, 255, 255, 255}, 256, 256, Bilinear, 1, 180},
+	{"assets/monarch.jpg", hashtype.Binary{255, 63, 12, 0, 0, 144, 248, 255}, 256, 256, Bilinear, 1, 180},
+	{"assets/peppers.jpg", hashtype.Binary{9, 0, 40, 32, 168, 251, 255, 255}, 256, 256, Bilinear, 1, 180},
+	{"assets/tulips.jpg", hashtype.Binary{119, 224, 1, 128, 0, 240, 255, 255}, 256, 256, Bilinear, 1, 180},
+}
+
+func TestRASH_Calculate(t *testing.T) {
+	for _, tt := range rashCalculateTests {
+		t.Run(tt.filename, func(t *testing.T) {
+			hash, err := NewRASH(WithSize(tt.width, tt.height), WithInterpolation(tt.resizeType), WithSigma(tt.sigma), WithRings(tt.rings))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img, err := OpenImage(tt.filename)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.filename, err)
+			}
+			result, err := hash.Calculate(img)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			res := result.(hashtype.Binary)
+			if !res.Equal(tt.hash) {
+				t.Errorf("got %v, want %v", res, tt.hash)
+			}
+		})
+	}
+}
+
+func ExampleRASH_Calculate() {
+	img, err := OpenImage("assets/cat.jpg")
+	if err != nil {
+		panic(err)
+	}
+	rash, err := NewRASH()
+	if err != nil {
+		panic(err)
+	}
+	hash, err := rash.Calculate(img)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hash)
+	// Output: [46 0 64 32 128 255 255 255]
+}
+
+var rashDistanceTests = []struct {
+	firstImage  string
+	secondImage string
+	distance    similarity.Distance
+	width       uint
+	height      uint
+	resizeType  Interpolation
+	sigma       float64
+	rings       int
+}{
+	{"assets/lena.jpg", "assets/cat.jpg", 10, 256, 256, Bilinear, 1, 180},
+	{"assets/lena.jpg", "assets/monarch.jpg", 28, 256, 256, Bilinear, 1, 180},
+	{"assets/baboon.jpg", "assets/cat.jpg", 20, 256, 256, Bilinear, 1, 180},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 20, 256, 256, Bilinear, 1, 180},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 18, 256, 256, Bilinear, 1, 180},
+}
+
+func TestRASH_Distance(t *testing.T) {
+	for _, tt := range rashDistanceTests {
+		t.Run(fmt.Sprintf("%v %v", tt.firstImage, tt.secondImage), func(t *testing.T) {
+			hash, err := NewRASH(WithSize(tt.width, tt.height), WithInterpolation(tt.resizeType), WithSigma(tt.sigma), WithRings(tt.rings))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img1, err := OpenImage(tt.firstImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.firstImage, err)
+			}
+			img2, err := OpenImage(tt.secondImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.secondImage, err)
+			}
+			h1, err := hash.Calculate(img1)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.firstImage, err)
+			}
+			h2, err := hash.Calculate(img2)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
+			}
+			dist, err := similarity.Hamming(h1, h2)
+			if err != nil {
+				t.Fatalf("failed to compute distance: %v", err)
+			}
+			if !dist.Equal(tt.distance) {
+				t.Errorf("got %v, want %v", dist, tt.distance)
+			}
+		})
+	}
+}
+
+func TestNewRASH_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []RASHOption
+		err  error
+	}{
+		{"zero width", []RASHOption{WithSize(0, 256)}, ErrInvalidSize},
+		{"zero height", []RASHOption{WithSize(256, 0)}, ErrInvalidSize},
+		{"negative sigma", []RASHOption{WithSigma(-1)}, ErrInvalidSigma},
+		{"zero rings", []RASHOption{WithRings(0)}, ErrInvalidRings},
+		{"negative rings", []RASHOption{WithRings(-1)}, ErrInvalidRings},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := NewRASH(tt.opts...)
+			if err != tt.err {
+				t.Errorf("got %v, want %v", err, tt.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add RASH (Rotation Aware Spatial Hash), a new perceptual hash algorithm that is robust against image rotation. It uses concentric ring sampling, a 1-D DCT, and median thresholding to produce a 64-bit binary hash.
- Update README to document the new algorithm, recommend PDQ as the default choice in Quick Start, and bump the algorithm count to 13.

## Type of Change

- [x] `feat` (new feature)
- [x] `docs` (documentation only)
- [x] `test` (tests only)

## Validation

All existing and new tests pass:

```bash
go test ./... -count=1
```

New test coverage for RASH includes:
- Hash calculation against 6 reference images
- Hamming distance for 5 image pairs
- Constructor error validation (invalid size, sigma, rings)
- Example function with expected output

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).