### PR TITLE
feat: distance metrics and per-algorithm Compare methods

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -126,10 +126,29 @@ bin := h1.(imghash.Binary)
 | `similarity.PCCFloat64(f1, f2)` | `similarity.PCC(h1, h2)` |
 | `similarity.PCCUInt8(u1, u2)` | `similarity.PCC(h1, h2)` |
 
-For most callers, the new top-level helper is simpler:
+**Preferred: use the algorithm's `Compare` method.** Every hash algorithm now has
+a `Compare` method that applies the recommended distance metric for that algorithm
+(e.g. Hamming for binary hashes, chi-square for LBP, cosine for HOG):
 
 ```go
+pdq, _ := imghash.NewPDQ()
+h1, _ := pdq.Calculate(img1)
+h2, _ := pdq.Calculate(img2)
+dist, err := pdq.Compare(h1, h2)
+```
+
+The generic top-level helper and the `similarity` sub-package remain available
+for callers who need a specific metric regardless of algorithm:
+
+```go
+// Generic comparison based on hash type (Hamming for Binary, L2 for UInt8/Float64)
 dist, err := imghash.Compare(h1, h2)
+
+// Specific metric via the similarity package
+dist := similarity.ChiSquare(h1, h2)
+dist := similarity.Cosine(h1, h2)
+dist := similarity.L1(h1, h2)
+dist, err := similarity.WeightedHamming(h1, h2, weights)
 ```
 
 ## 7. Optional: adopt new convenience helpers

--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ func main() {
     panic(err)
   }
 
-  dist, err := imghash.Compare(h1, h2)
+  // Use the algorithm's recommended distance metric
+  dist, err := pdq.Compare(h1, h2)
   if err != nil {
     panic(err)
   }
@@ -79,7 +80,7 @@ The library provides helpers so you don't need image decoding boilerplate:
 | `HashReader(hasher, r)` | Decodes from a reader and computes the hash |
 | `Compare(h1, h2)` | Computes distance using the natural metric for the hash type |
 
-You can also call `h1.Distance(h2)` directly on any hash value.
+You can also call `h1.Distance(h2)` directly on any hash value, or use the algorithm's `Compare` method for the recommended metric (see [Similarity Metrics](#similarity-metrics)).
 
 ## Perceptual Hash Algorithms
 
@@ -104,7 +105,9 @@ Produces a 64-bit binary hash. Compares using Hamming distance. Based on [Looks 
 
 ```go
 avg, err := imghash.NewAverage()
-hash, err := avg.Calculate(img)
+h1, err := avg.Calculate(img1)
+h2, err := avg.Calculate(img2)
+dist, err := avg.Compare(h1, h2) // Hamming distance
 ```
 
 | Option | Default |
@@ -114,11 +117,13 @@ hash, err := avg.Calculate(img)
 
 #### Difference Hash
 
-Very similar to Average but computes gradients instead of averages. Based on [Kind of Like That](https://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html).
+Very similar to Average but computes gradients instead of averages. Compares using Hamming distance. Based on [Kind of Like That](https://www.hackerfactor.com/blog/index.php?/archives/529-Kind-of-Like-That.html).
 
 ```go
 diff, err := imghash.NewDifference()
-hash, err := diff.Calculate(img)
+h1, err := diff.Calculate(img1)
+h2, err := diff.Calculate(img2)
+dist, err := diff.Compare(h1, h2) // Hamming distance
 ```
 
 | Option | Default |
@@ -128,11 +133,13 @@ hash, err := diff.Calculate(img)
 
 #### Median Hash
 
-Almost identical to Average hash but uses the median instead of the mean.
+Almost identical to Average hash but uses the median instead of the mean. Compares using Hamming distance.
 
 ```go
 med, err := imghash.NewMedian()
-hash, err := med.Calculate(img)
+h1, err := med.Calculate(img1)
+h2, err := med.Calculate(img2)
+dist, err := med.Compare(h1, h2) // Hamming distance
 ```
 
 | Option | Default |
@@ -142,25 +149,30 @@ hash, err := med.Calculate(img)
 
 #### pHash
 
-Uses a discrete cosine transform to produce a 64-bit binary hash. From [Rihamark: Perceptual image hash benchmarking](https://www.researchgate.net/publication/252340846_Rihamark_Perceptual_image_hash_benchmarking).
+Uses a discrete cosine transform to produce a 64-bit binary hash. Compares using weighted Hamming distance, where each byte position can be assigned a different weight (defaults to uniform). From [Rihamark: Perceptual image hash benchmarking](https://www.researchgate.net/publication/252340846_Rihamark_Perceptual_image_hash_benchmarking).
 
 ```go
 ph, err := imghash.NewPHash()
-hash, err := ph.Calculate(img)
+h1, err := ph.Calculate(img1)
+h2, err := ph.Calculate(img2)
+dist, err := ph.Compare(h1, h2) // Weighted Hamming distance
 ```
 
 | Option | Default |
 |--------|---------|
 | `WithSize(w, h)` | 32, 32 |
 | `WithInterpolation(i)` | `BilinearExact` |
+| `WithWeights(w)` | `[1, 1, 1, 1, 1, 1, 1, 1]` |
 
 #### Wavelet Hash (wHash)
 
-Uses a multi-level Haar discrete wavelet transform to produce a 64-bit binary hash. The image is resized to `(width * 2^level) x (height * 2^level)`, converted to grayscale, and decomposed via the Haar DWT. The low-frequency (LL) subband coefficients are thresholded against their median. See [Wavelet image hash](https://fullstackml.com/wavelet-image-hash-in-python-3504571f3b08) for more information.
+Uses a multi-level Haar discrete wavelet transform to produce a 64-bit binary hash. Compares using Hamming distance. The image is resized to `(width * 2^level) x (height * 2^level)`, converted to grayscale, and decomposed via the Haar DWT. The low-frequency (LL) subband coefficients are thresholded against their median. See [Wavelet image hash](https://fullstackml.com/wavelet-image-hash-in-python-3504571f3b08) for more information.
 
 ```go
 wh, err := imghash.NewWHash()
-hash, err := wh.Calculate(img)
+h1, err := wh.Calculate(img1)
+h2, err := wh.Calculate(img2)
+dist, err := wh.Compare(h1, h2) // Hamming distance
 ```
 
 | Option | Default |
@@ -171,11 +183,13 @@ hash, err := wh.Calculate(img)
 
 #### Color Moments Hash
 
-Builds a 42-element float64 vector from YCbCr and HSV color moments. Based on [Perceptual hashing for color images using invariant moments](https://www.researchgate.net/publication/286870507_Perceptual_hashing_for_color_images_using_invariant_moments).
+Builds a 42-element float64 vector from YCbCr and HSV color moments. Compares using L2 (Euclidean) distance. Based on [Perceptual hashing for color images using invariant moments](https://www.researchgate.net/publication/286870507_Perceptual_hashing_for_color_images_using_invariant_moments).
 
 ```go
 cm, err := imghash.NewColorMoment()
-hash, err := cm.Calculate(img)
+h1, err := cm.Calculate(img1)
+h2, err := cm.Calculate(img2)
+dist := cm.Compare(h1, h2) // L2 distance
 ```
 
 | Option | Default |
@@ -187,11 +201,13 @@ hash, err := cm.Calculate(img)
 
 #### Marr-Hildreth Hash
 
-Uses a 2D wavelet transform to produce a 576-bit binary hash. From [Rihamark: Perceptual image hash benchmarking](https://www.researchgate.net/publication/252340846_Rihamark_Perceptual_image_hash_benchmarking).
+Uses a 2D wavelet transform to produce a 576-bit binary hash. Compares using Hamming distance. From [Rihamark: Perceptual image hash benchmarking](https://www.researchgate.net/publication/252340846_Rihamark_Perceptual_image_hash_benchmarking).
 
 ```go
 mh, err := imghash.NewMarrHildreth()
-hash, err := mh.Calculate(img)
+h1, err := mh.Calculate(img1)
+h2, err := mh.Calculate(img2)
+dist, err := mh.Compare(h1, h2) // Hamming distance
 ```
 
 | Option | Default |
@@ -205,11 +221,13 @@ hash, err := mh.Calculate(img)
 
 #### Block Mean Value Hash
 
-Computes means using a sliding window to produce a 256-bit binary hash. Based on [Block Mean Value Based Image Perceptual Hashing](https://ieeexplore.ieee.org/document/4041692).
+Computes means using a sliding window to produce a 256-bit binary hash. Compares using Hamming distance. Based on [Block Mean Value Based Image Perceptual Hashing](https://ieeexplore.ieee.org/document/4041692).
 
 ```go
 bm, err := imghash.NewBlockMean()
-hash, err := bm.Calculate(img)
+h1, err := bm.Calculate(img1)
+h2, err := bm.Calculate(img2)
+dist, err := bm.Compare(h1, h2) // Hamming distance
 ```
 
 | Option | Default |
@@ -223,11 +241,13 @@ Block mean methods: `Direct`, `Overlap`, `Rotation`, `RotationOverlap`.
 
 #### Local Binary Pattern (LBP) Hash
 
-Computes a 3x3 Local Binary Pattern code for each pixel and builds a normalized 256-bin histogram per grid cell, producing a uint8 vector. The grid can be increased for spatially-aware hashing. Based on [Multiresolution Gray-Scale and Rotation Invariant Texture Classification with Local Binary Patterns](https://ieeexplore.ieee.org/document/1017623) by Ojala et al.
+Computes a 3x3 Local Binary Pattern code for each pixel and builds a normalized 256-bin histogram per grid cell, producing a uint8 vector. Compares using chi-square distance, which is well suited for histogram comparison. The grid can be increased for spatially-aware hashing. Based on [Multiresolution Gray-Scale and Rotation Invariant Texture Classification with Local Binary Patterns](https://ieeexplore.ieee.org/document/1017623) by Ojala et al.
 
 ```go
 lbp, err := imghash.NewLBP()
-hash, err := lbp.Calculate(img)
+h1, err := lbp.Calculate(img1)
+h2, err := lbp.Calculate(img2)
+dist := lbp.Compare(h1, h2) // Chi-square distance
 ```
 
 | Option | Default |
@@ -240,11 +260,13 @@ With the default 1x1 grid the hash is a 256-element uint8 vector. Set `WithGridS
 
 #### HOG Hash (Histogram of Oriented Gradients)
 
-Computes gradient magnitudes and orientations at each pixel, divides the image into square cells, and builds a magnitude-weighted orientation histogram per cell. The histograms are normalized and concatenated into a uint8 vector. Based on [Histograms of Oriented Gradients for Human Detection](https://ieeexplore.ieee.org/document/1467360) by Dalal and Triggs.
+Computes gradient magnitudes and orientations at each pixel, divides the image into square cells, and builds a magnitude-weighted orientation histogram per cell. The histograms are normalized and concatenated into a uint8 vector. Compares using cosine distance, which measures orientation similarity independent of magnitude scaling. Based on [Histograms of Oriented Gradients for Human Detection](https://ieeexplore.ieee.org/document/1467360) by Dalal and Triggs.
 
 ```go
 hog, err := imghash.NewHOGHash()
-hash, err := hog.Calculate(img)
+h1, err := hog.Calculate(img1)
+h2, err := hog.Calculate(img2)
+dist := hog.Compare(h1, h2) // Cosine distance
 ```
 
 | Option | Default |
@@ -258,11 +280,13 @@ With default settings the hash is a 9216-element uint8 vector (32×32 cells × 9
 
 #### Radial Variance Hash
 
-Uses radial projections and feature vector computations to generate a 40-element uint8 vector. From [Robust image hashing based on radial variance of pixels](https://www.researchgate.net/publication/4186555_Robust_image_hashing_based_on_radial_variance_of_pixels).
+Uses radial projections and feature vector computations to generate a 40-element uint8 vector. Compares using L1 (Manhattan) distance. From [Robust image hashing based on radial variance of pixels](https://www.researchgate.net/publication/4186555_Robust_image_hashing_based_on_radial_variance_of_pixels).
 
 ```go
 rv, err := imghash.NewRadialVariance()
-hash, err := rv.Calculate(img)
+h1, err := rv.Calculate(img1)
+h2, err := rv.Calculate(img2)
+dist := rv.Compare(h1, h2) // L1 distance
 ```
 
 | Option | Default |
@@ -272,11 +296,13 @@ hash, err := rv.Calculate(img)
 
 #### RASH (Rotation Aware Spatial Hash)
 
-Produces a 64-bit binary hash designed to be robust against image rotation. This is a custom algorithm that combines concentric ring sampling for rotation invariance, a 1-D DCT for frequency compaction, and median thresholding for binarisation. The algorithm resizes the image, converts to grayscale, applies Gaussian blur, then samples pixel intensities on concentric rings around the image centre. Because ring-mean features are inherently rotation-invariant (rotating the image only permutes pixels within a ring, leaving its mean unchanged), the resulting hash stays stable under arbitrary rotations. Compares using Hamming distance. Inspired by ring-partition hashing literature such as [Robust Image Hashing with Ring Partition and Invariant Vector Distance](https://ieeexplore.ieee.org/document/7368930) by Tang et al. and [Robust image hashing based on radial variance of pixels](https://www.researchgate.net/publication/4186555_Robust_image_hashing_based_on_radial_variance_of_pixels) by De Roover et al.
+Produces a 64-bit binary hash designed to be robust against image rotation. Compares using Hamming distance. This is a custom algorithm that combines concentric ring sampling for rotation invariance, a 1-D DCT for frequency compaction, and median thresholding for binarisation. The algorithm resizes the image, converts to grayscale, applies Gaussian blur, then samples pixel intensities on concentric rings around the image centre. Because ring-mean features are inherently rotation-invariant (rotating the image only permutes pixels within a ring, leaving its mean unchanged), the resulting hash stays stable under arbitrary rotations. Inspired by ring-partition hashing literature such as [Robust Image Hashing with Ring Partition and Invariant Vector Distance](https://ieeexplore.ieee.org/document/7368930) by Tang et al. and [Robust image hashing based on radial variance of pixels](https://www.researchgate.net/publication/4186555_Robust_image_hashing_based_on_radial_variance_of_pixels) by De Roover et al.
 
 ```go
 rash, err := imghash.NewRASH()
-hash, err := rash.Calculate(img)
+h1, err := rash.Calculate(img1)
+h2, err := rash.Calculate(img2)
+dist, err := rash.Compare(h1, h2) // Hamming distance
 ```
 
 | Option | Default |
@@ -288,11 +314,13 @@ hash, err := rash.Calculate(img)
 
 #### PDQ Hash
 
-Produces a 256-bit binary hash designed for large-scale image deduplication. The algorithm resizes to 64×64, applies a Jarosz box filter for noise smoothing, computes a 2D DCT, and thresholds the 16×16 low-frequency coefficients against their median. Robust to JPEG compression, rescaling, and minor edits. From Facebook (Meta) [ThreatExchange PDQ](https://github.com/facebook/ThreatExchange/tree/main/pdq).
+Produces a 256-bit binary hash designed for large-scale image deduplication. Compares using Hamming distance. The algorithm resizes to 64×64, applies a Jarosz box filter for noise smoothing, computes a 2D DCT, and thresholds the 16×16 low-frequency coefficients against their median. Robust to JPEG compression, rescaling, and minor edits. From Facebook (Meta) [ThreatExchange PDQ](https://github.com/facebook/ThreatExchange/tree/main/pdq).
 
 ```go
 pdq, err := imghash.NewPDQ()
-hash, err := pdq.Calculate(img)
+h1, err := pdq.Calculate(img1)
+h2, err := pdq.Calculate(img2)
+dist, err := pdq.Compare(h1, h2) // Hamming distance
 ```
 
 | Option | Default |
@@ -303,7 +331,38 @@ The input size is fixed at 64×64 per the algorithm specification and is not con
 
 ## Similarity Metrics
 
-Every hash has a `Distance(other)` method that uses the natural metric for its type:
+### Algorithm-specific `Compare`
+
+Every hash algorithm has a `Compare` method that uses the recommended distance metric for that algorithm. This is the preferred way to compare hashes:
+
+```go
+pdq, _ := imghash.NewPDQ()
+h1, _ := imghash.HashFile(pdq, "image1.png")
+h2, _ := imghash.HashFile(pdq, "image2.png")
+dist, err := pdq.Compare(h1, h2)
+```
+
+The default metric per algorithm:
+
+| Algorithm | Hash type | Default `Compare` metric |
+|-----------|-----------|--------------------------|
+| Average | `Binary` | Hamming |
+| Difference | `Binary` | Hamming |
+| Median | `Binary` | Hamming |
+| PHash | `Binary` | Weighted Hamming |
+| WHash | `Binary` | Hamming |
+| MarrHildreth | `Binary` | Hamming |
+| BlockMean | `Binary` | Hamming |
+| PDQ | `Binary` | Hamming |
+| RASH | `Binary` | Hamming |
+| ColorMoment | `Float64` | L2 (Euclidean) |
+| LBP | `UInt8` | Chi-Square |
+| HOGHash | `UInt8` | Cosine |
+| RadialVariance | `UInt8` | L1 (Manhattan) |
+
+### Hash-level `Distance`
+
+Every hash also has a `Distance(other)` method that uses a generic metric based on the hash type:
 
 | Hash type | Default metric | Description |
 |-----------|---------------|-------------|
@@ -311,26 +370,26 @@ Every hash has a `Distance(other)` method that uses the natural metric for its t
 | `UInt8` | L2 (Euclidean) | Square root of sum of squared differences |
 | `Float64` | L2 (Euclidean) | Square root of sum of squared differences |
 
-For direct use:
-
 ```go
 dist, err := h1.Distance(h2)
-```
-
-Or via the top-level convenience which returns a `Distance` value:
-
-```go
+// or via the top-level convenience:
 dist, err := imghash.Compare(h1, h2)
 ```
 
-For advanced use cases (e.g. Pearson Correlation), use the `similarity` sub-package:
+### Available metrics
+
+The `similarity` sub-package provides all metrics for direct use:
 
 ```go
 import "github.com/ajdnik/imghash/v2/similarity"
 
-dist := similarity.L2(h1, h2)
-dist, err := similarity.PCC(h1, h2)
-dist, err := similarity.Hamming(h1, h2)
+dist, err := similarity.Hamming(h1, h2)          // bit-level Hamming distance (Binary only)
+dist, err := similarity.WeightedHamming(h1, h2, weights) // weighted Hamming (Binary only)
+dist := similarity.L1(h1, h2)                     // Manhattan distance
+dist := similarity.L2(h1, h2)                     // Euclidean distance
+dist := similarity.ChiSquare(h1, h2)              // Chi-square distance
+dist := similarity.Cosine(h1, h2)                 // Cosine distance (1 - cos similarity)
+dist, err := similarity.PCC(h1, h2)               // Peak cross-correlation
 ```
 
 ## Interpolation Methods

--- a/average.go
+++ b/average.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // Average is a perceptual hash that uses the method described in Looks Like It by Dr. Neal Krawetz.
@@ -49,4 +50,9 @@ func (ah Average) Calculate(img image.Image) (hashtype.Hash, error) {
 		return nil, err
 	}
 	return thresholdHash(g, uint(math.Round(m))), nil
+}
+
+// Compare computes the Hamming distance between two Average hashes.
+func (ah Average) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	return similarity.Hamming(h1, h2)
 }

--- a/average_test.go
+++ b/average_test.go
@@ -107,7 +107,7 @@ func TestAverage_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}

--- a/blockmean.go
+++ b/blockmean.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // BlockMean is a perceptual hash that uses the method described in
@@ -123,4 +124,9 @@ func (bh BlockMean) computeHash(means []float64, median float64) hashtype.Binary
 		}
 	}
 	return hash
+}
+
+// Compare computes the Hamming distance between two BlockMean hashes.
+func (bh BlockMean) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	return similarity.Hamming(h1, h2)
 }

--- a/blockmean_test.go
+++ b/blockmean_test.go
@@ -124,7 +124,7 @@ func TestBlockMean_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}

--- a/colormoment.go
+++ b/colormoment.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // ColorMoment is a perceptual hash that uses the method described in
@@ -76,4 +77,9 @@ func (ch ColorMoment) Calculate(img image.Image) (hashtype.Hash, error) {
 		hash[i] = yHuMom[i-len(hHuMom)]
 	}
 	return hash, nil
+}
+
+// Compare computes the L2 (Euclidean) distance between two ColorMoment hashes.
+func (ch ColorMoment) Compare(h1, h2 hashtype.Hash) similarity.Distance {
+	return similarity.L2(h1, h2)
 }

--- a/colormoment_test.go
+++ b/colormoment_test.go
@@ -110,7 +110,7 @@ func TestColorMoment_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist := similarity.L2(h1, h2)
+			dist := hash.Compare(h1, h2)
 			if !dist.Equal(tt.distance) {
 				t.Errorf("got %v, want %v", dist, tt.distance)
 			}

--- a/difference.go
+++ b/difference.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // Difference is a perceptual hash that uses the method described in Kinf of Like That by Dr. Neal Krawetz.
@@ -63,4 +64,9 @@ func (dh Difference) computeHash(img *image.Gray) hashtype.Binary {
 		}
 	}
 	return hash
+}
+
+// Compare computes the Hamming distance between two Difference hashes.
+func (dh Difference) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	return similarity.Hamming(h1, h2)
 }

--- a/difference_test.go
+++ b/difference_test.go
@@ -109,7 +109,7 @@ func TestDifference_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}

--- a/hoghash.go
+++ b/hoghash.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // HOGHash is a perceptual hash based on Histogram of Oriented Gradients.
@@ -164,4 +165,9 @@ func (hh HOGHash) computeHash(mag, orient []float64, w, h int) hashtype.UInt8 {
 		}
 	}
 	return hash
+}
+
+// Compare computes the cosine distance between two HOGHash hashes.
+func (hh HOGHash) Compare(h1, h2 hashtype.Hash) similarity.Distance {
+	return similarity.Cosine(h1, h2)
 }

--- a/hoghash_test.go
+++ b/hoghash_test.go
@@ -77,11 +77,11 @@ var hogHashDistanceTests = []struct {
 	cellSize    uint
 	numBins     uint
 }{
-	{"assets/lena.jpg", "assets/cat.jpg", 1530.9330488300263, 32, 32, Bilinear, 8, 9},
-	{"assets/lena.jpg", "assets/monarch.jpg", 1315.5991030705366, 32, 32, Bilinear, 8, 9},
-	{"assets/baboon.jpg", "assets/cat.jpg", 1403.76386903211, 32, 32, Bilinear, 8, 9},
-	{"assets/peppers.jpg", "assets/baboon.jpg", 1183.0942481476275, 32, 32, Bilinear, 8, 9},
-	{"assets/tulips.jpg", "assets/monarch.jpg", 1056.4710123803682, 32, 32, Bilinear, 8, 9},
+	{"assets/lena.jpg", "assets/cat.jpg", 0.509984487750516, 32, 32, Bilinear, 8, 9},
+	{"assets/lena.jpg", "assets/monarch.jpg", 0.3223155603833341, 32, 32, Bilinear, 8, 9},
+	{"assets/baboon.jpg", "assets/cat.jpg", 0.4056824811720108, 32, 32, Bilinear, 8, 9},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 0.28314243977711895, 32, 32, Bilinear, 8, 9},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 0.17623016930102986, 32, 32, Bilinear, 8, 9},
 }
 
 func TestHOGHash_Distance(t *testing.T) {
@@ -107,7 +107,7 @@ func TestHOGHash_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist := similarity.L2(h1, h2)
+			dist := hash.Compare(h1, h2)
 			if !dist.Equal(tt.distance) {
 				t.Errorf("got %v, want %v", dist, tt.distance)
 			}

--- a/lbp.go
+++ b/lbp.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // LBP is a perceptual hash based on Local Binary Patterns.
@@ -135,4 +136,9 @@ func (lh LBP) computeHash(lbpImg []uint8, w, h int) hashtype.UInt8 {
 		}
 	}
 	return hash
+}
+
+// Compare computes the chi-square distance between two LBP hashes.
+func (lh LBP) Compare(h1, h2 hashtype.Hash) similarity.Distance {
+	return similarity.ChiSquare(h1, h2)
 }

--- a/lbp_test.go
+++ b/lbp_test.go
@@ -77,11 +77,11 @@ var lbpDistanceTests = []struct {
 	gridX       uint
 	gridY       uint
 }{
-	{"assets/lena.jpg", "assets/cat.jpg", 482.6240773106953, 256, 256, Bilinear, 1, 1},
-	{"assets/lena.jpg", "assets/monarch.jpg", 148.6674140489435, 256, 256, Bilinear, 1, 1},
-	{"assets/baboon.jpg", "assets/cat.jpg", 361.8535615411295, 256, 256, Bilinear, 1, 1},
-	{"assets/peppers.jpg", "assets/baboon.jpg", 337.358859376777, 256, 256, Bilinear, 1, 1},
-	{"assets/tulips.jpg", "assets/monarch.jpg", 228.75314205492347, 256, 256, Bilinear, 1, 1},
+	{"assets/lena.jpg", "assets/cat.jpg", 1408.0953514028656, 256, 256, Bilinear, 1, 1},
+	{"assets/lena.jpg", "assets/monarch.jpg", 252.35802418352222, 256, 256, Bilinear, 1, 1},
+	{"assets/baboon.jpg", "assets/cat.jpg", 775.0799875837864, 256, 256, Bilinear, 1, 1},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 783.2270861965849, 256, 256, Bilinear, 1, 1},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 407.0482265310037, 256, 256, Bilinear, 1, 1},
 }
 
 func TestLBP_Distance(t *testing.T) {
@@ -107,7 +107,7 @@ func TestLBP_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist := similarity.L2(h1, h2)
+			dist := hash.Compare(h1, h2)
 			if !dist.Equal(tt.distance) {
 				t.Errorf("got %v, want %v", dist, tt.distance)
 			}

--- a/marrhildreth.go
+++ b/marrhildreth.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 const (
@@ -151,4 +152,9 @@ func computeMarrHildrethKernel(alpha, level float64) [][]float32 {
 		}
 	}
 	return kernel
+}
+
+// Compare computes the Hamming distance between two MarrHildreth hashes.
+func (mhh MarrHildreth) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	return similarity.Hamming(h1, h2)
 }

--- a/marrhildreth_test.go
+++ b/marrhildreth_test.go
@@ -115,7 +115,7 @@ func TestMarrHildreth_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}

--- a/medianhash.go
+++ b/medianhash.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // Median is a perceptual hash that uses a similar approach as Average hash.
@@ -49,4 +50,9 @@ func (mh Median) Calculate(img image.Image) (hashtype.Hash, error) {
 		return nil, err
 	}
 	return thresholdHash(g, uint(math.Round(med))), nil
+}
+
+// Compare computes the Hamming distance between two Median hashes.
+func (mh Median) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	return similarity.Hamming(h1, h2)
 }

--- a/medianhash_test.go
+++ b/medianhash_test.go
@@ -109,7 +109,7 @@ func TestMedian_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}

--- a/options.go
+++ b/options.go
@@ -125,6 +125,10 @@ type ringsOption struct{ rings int }
 
 func (o ringsOption) applyRASH(r *RASH) { r.rings = o.rings }
 
+type weightsOption struct{ weights []float64 }
+
+func (o weightsOption) applyPHash(p *PHash) { p.weights = o.weights }
+
 // --- public constructors ---
 
 // WithSize sets the resize dimensions used during hash computation.
@@ -210,4 +214,11 @@ func WithNumBins(bins uint) numBinsOption {
 // Applies to RASH.
 func WithRings(rings int) ringsOption {
 	return ringsOption{rings}
+}
+
+// WithWeights sets the per-byte weights used for weighted Hamming distance.
+// The slice length must match the number of hash bytes (8 for default PHash).
+// Applies to PHash.
+func WithWeights(weights []float64) weightsOption {
+	return weightsOption{weights}
 }

--- a/options_typecheck_test.go
+++ b/options_typecheck_test.go
@@ -15,6 +15,7 @@ var _ MedianOption = WithInterpolation(Bilinear)
 
 var _ PHashOption = WithSize(0, 0)
 var _ PHashOption = WithInterpolation(Bilinear)
+var _ PHashOption = WithWeights(nil)
 
 var _ BlockMeanOption = WithSize(0, 0)
 var _ BlockMeanOption = WithInterpolation(Bilinear)

--- a/pdq.go
+++ b/pdq.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // pdqDCTSize is the dimension of the DCT input buffer.
@@ -99,4 +100,9 @@ func (p PDQ) computeHash(block [][]float32, median float32) hashtype.Binary {
 		}
 	}
 	return hash
+}
+
+// Compare computes the Hamming distance between two PDQ hashes.
+func (p PDQ) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	return similarity.Hamming(h1, h2)
 }

--- a/pdq_test.go
+++ b/pdq_test.go
@@ -99,7 +99,7 @@ func TestPDQ_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}

--- a/phash_test.go
+++ b/phash_test.go
@@ -107,7 +107,7 @@ func TestPHash_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}

--- a/radialvariance.go
+++ b/radialvariance.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // RadialVariance is a perceptual hash that uses the method described in
@@ -169,4 +170,9 @@ func (rv RadialVariance) computeHash(feat []float64) hashtype.UInt8 {
 		hash[i] = uint8((255 * (temp[i] - min) / r))
 	}
 	return hash
+}
+
+// Compare computes the L1 (Manhattan) distance between two RadialVariance hashes.
+func (rv RadialVariance) Compare(h1, h2 hashtype.Hash) similarity.Distance {
+	return similarity.L1(h1, h2)
 }

--- a/radialvariance_test.go
+++ b/radialvariance_test.go
@@ -88,11 +88,11 @@ var radialVarianceDistanceTests = []struct {
 	sigma       float64
 	angles      int
 }{
-	{"assets/lena.jpg", "assets/cat.jpg", 0.247818888750317, 1, 180},
-	{"assets/lena.jpg", "assets/monarch.jpg", 0.6339729738012116, 1, 180},
-	{"assets/baboon.jpg", "assets/cat.jpg", 0.31577803436311935, 1, 180},
-	{"assets/peppers.jpg", "assets/baboon.jpg", 0.5791217549142161, 1, 180},
-	{"assets/tulips.jpg", "assets/monarch.jpg", 0.5199454464617648, 1, 180},
+	{"assets/lena.jpg", "assets/cat.jpg", 2514, 1, 180},
+	{"assets/lena.jpg", "assets/monarch.jpg", 1621, 1, 180},
+	{"assets/baboon.jpg", "assets/cat.jpg", 4228, 1, 180},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 918, 1, 180},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 1586, 1, 180},
 }
 
 func TestRadialVariance_Distance(t *testing.T) {
@@ -118,10 +118,7 @@ func TestRadialVariance_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.PCC(h1, h2)
-			if err != nil {
-				t.Fatalf("failed to compute distance: %v", err)
-			}
+			dist := hash.Compare(h1, h2)
 			if math.Abs(float64(dist)-float64(tt.distance)) > 0.01 {
 				t.Errorf("got %v, want %v", dist, tt.distance)
 			}

--- a/rash.go
+++ b/rash.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // RASH is a Rotation Aware Spatial Hash — a perceptual hash designed to be
@@ -143,4 +144,9 @@ func (r RASH) computeHash(means []float64) hashtype.Binary {
 		}
 	}
 	return hash
+}
+
+// Compare computes the Hamming distance between two RASH hashes.
+func (r RASH) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	return similarity.Hamming(h1, h2)
 }

--- a/rash_test.go
+++ b/rash_test.go
@@ -107,7 +107,7 @@ func TestRASH_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}

--- a/similarity/chisquare.go
+++ b/similarity/chisquare.go
@@ -1,0 +1,27 @@
+package similarity
+
+import (
+	"github.com/ajdnik/imghash/v2/hashtype"
+)
+
+// ChiSquare calculates the chi-square distance between two hashes.
+// For each element pair it computes (a - b)^2 / (a + b), skipping
+// positions where both values are zero to avoid division by zero.
+func ChiSquare(h1, h2 hashtype.Hash) Distance {
+	l := h1.Len()
+	if h2.Len() < l {
+		l = h2.Len()
+	}
+	var s float64
+	for i := 0; i < l; i++ {
+		a := h1.ValueAt(i)
+		b := h2.ValueAt(i)
+		sum := a + b
+		if sum == 0 {
+			continue
+		}
+		d := a - b
+		s += (d * d) / sum
+	}
+	return Distance(s)
+}

--- a/similarity/chisquare_test.go
+++ b/similarity/chisquare_test.go
@@ -1,0 +1,63 @@
+package similarity_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	. "github.com/ajdnik/imghash/v2/similarity"
+)
+
+var chiSquareUint8Tests = []struct {
+	name  string
+	hash1 hashtype.UInt8
+	hash2 hashtype.UInt8
+	out   Distance
+}{
+	{"same hashes", hashtype.UInt8{10, 20, 30}, hashtype.UInt8{10, 20, 30}, Distance(0)},
+	{"simple case", hashtype.UInt8{10, 20, 30}, hashtype.UInt8{15, 25, 35}, Distance(1.9401709401709402)},
+	{"with zero pair", hashtype.UInt8{0, 20, 30}, hashtype.UInt8{0, 25, 35}, Distance(0.9401709401709402)},
+	{"one zero", hashtype.UInt8{0, 10}, hashtype.UInt8{5, 10}, Distance(5)},
+}
+
+func TestChiSquareUint8(t *testing.T) {
+	for _, tt := range chiSquareUint8Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := ChiSquare(tt.hash1, tt.hash2)
+			if !res.Equal(tt.out) {
+				t.Errorf("got %v, want %v", res, tt.out)
+			}
+		})
+	}
+}
+
+var chiSquareFloat64Tests = []struct {
+	name  string
+	hash1 hashtype.Float64
+	hash2 hashtype.Float64
+	out   Distance
+}{
+	{"same hashes", hashtype.Float64{1.0, 2.0, 3.0}, hashtype.Float64{1.0, 2.0, 3.0}, Distance(0)},
+	{"simple case", hashtype.Float64{1.0, 2.0, 3.0}, hashtype.Float64{2.0, 3.0, 4.0}, Distance(0.6761904761904762)},
+	{"both zeros skipped", hashtype.Float64{0.0, 2.0}, hashtype.Float64{0.0, 4.0}, Distance(0.6666666666666666)},
+}
+
+func TestChiSquareFloat64(t *testing.T) {
+	for _, tt := range chiSquareFloat64Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := ChiSquare(tt.hash1, tt.hash2)
+			if !res.Equal(tt.out) {
+				t.Errorf("got %v, want %v", res, tt.out)
+			}
+		})
+	}
+}
+
+func ExampleChiSquare() {
+	hash1 := hashtype.UInt8{10, 20, 30, 40}
+	hash2 := hashtype.UInt8{15, 25, 35, 45}
+
+	fmt.Println(ChiSquare(hash1, hash2))
+	// Output:
+	// 2.2342885872297638
+}

--- a/similarity/cosine.go
+++ b/similarity/cosine.go
@@ -1,0 +1,31 @@
+package similarity
+
+import (
+	"math"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+)
+
+// Cosine calculates the cosine distance between two hashes.
+// Cosine distance is defined as 1 - cos(theta), where cos(theta) is the
+// cosine similarity (dot product divided by the product of magnitudes).
+// Returns 0 when both hashes are zero vectors.
+func Cosine(h1, h2 hashtype.Hash) Distance {
+	l := h1.Len()
+	if h2.Len() < l {
+		l = h2.Len()
+	}
+	var dot, mag1, mag2 float64
+	for i := 0; i < l; i++ {
+		a := h1.ValueAt(i)
+		b := h2.ValueAt(i)
+		dot += a * b
+		mag1 += a * a
+		mag2 += b * b
+	}
+	denom := math.Sqrt(mag1) * math.Sqrt(mag2)
+	if denom == 0 {
+		return 0
+	}
+	return Distance(1 - dot/denom)
+}

--- a/similarity/cosine_test.go
+++ b/similarity/cosine_test.go
@@ -1,0 +1,64 @@
+package similarity_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	. "github.com/ajdnik/imghash/v2/similarity"
+)
+
+var cosineUint8Tests = []struct {
+	name  string
+	hash1 hashtype.UInt8
+	hash2 hashtype.UInt8
+	out   Distance
+}{
+	{"identical hashes", hashtype.UInt8{10, 20, 30}, hashtype.UInt8{10, 20, 30}, Distance(0)},
+	{"proportional hashes", hashtype.UInt8{1, 2, 3}, hashtype.UInt8{2, 4, 6}, Distance(0)},
+	{"orthogonal-like", hashtype.UInt8{1, 0, 0}, hashtype.UInt8{0, 1, 0}, Distance(1)},
+	{"different hashes", hashtype.UInt8{60, 67, 86, 64}, hashtype.UInt8{143, 213, 154, 170}, Distance(0.024536201729695284)},
+}
+
+func TestCosineUint8(t *testing.T) {
+	for _, tt := range cosineUint8Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Cosine(tt.hash1, tt.hash2)
+			if !res.Equal(tt.out) {
+				t.Errorf("got %v, want %v", res, tt.out)
+			}
+		})
+	}
+}
+
+var cosineFloat64Tests = []struct {
+	name  string
+	hash1 hashtype.Float64
+	hash2 hashtype.Float64
+	out   Distance
+}{
+	{"identical", hashtype.Float64{1.0, 2.0, 3.0}, hashtype.Float64{1.0, 2.0, 3.0}, Distance(0)},
+	{"opposite", hashtype.Float64{1.0, 0.0}, hashtype.Float64{-1.0, 0.0}, Distance(2)},
+	{"zero vectors", hashtype.Float64{0.0, 0.0}, hashtype.Float64{0.0, 0.0}, Distance(0)},
+	{"one zero vector", hashtype.Float64{1.0, 2.0}, hashtype.Float64{0.0, 0.0}, Distance(0)},
+}
+
+func TestCosineFloat64(t *testing.T) {
+	for _, tt := range cosineFloat64Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := Cosine(tt.hash1, tt.hash2)
+			if !res.Equal(tt.out) {
+				t.Errorf("got %v, want %v", res, tt.out)
+			}
+		})
+	}
+}
+
+func ExampleCosine() {
+	hash1 := hashtype.UInt8{60, 67, 86, 64, 58, 72, 68, 75}
+	hash2 := hashtype.UInt8{143, 213, 154, 170, 209, 125, 152, 173}
+
+	fmt.Println(Cosine(hash1, hash2))
+	// Output:
+	// 0.028706372204543307
+}

--- a/similarity/l1.go
+++ b/similarity/l1.go
@@ -1,0 +1,21 @@
+package similarity
+
+import (
+	"math"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+)
+
+// L1 calculates the L1 (Manhattan) distance between two hashes.
+// It sums the absolute differences of corresponding elements.
+func L1(h1, h2 hashtype.Hash) Distance {
+	l := h1.Len()
+	if h2.Len() < l {
+		l = h2.Len()
+	}
+	var s float64
+	for i := 0; i < l; i++ {
+		s += math.Abs(h1.ValueAt(i) - h2.ValueAt(i))
+	}
+	return Distance(s)
+}

--- a/similarity/l1_test.go
+++ b/similarity/l1_test.go
@@ -1,0 +1,63 @@
+package similarity_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	. "github.com/ajdnik/imghash/v2/similarity"
+)
+
+var l1Uint8Tests = []struct {
+	name  string
+	hash1 hashtype.UInt8
+	hash2 hashtype.UInt8
+	out   Distance
+}{
+	{"same hashes", hashtype.UInt8{10, 20, 30}, hashtype.UInt8{10, 20, 30}, Distance(0)},
+	{"single element", hashtype.UInt8{10}, hashtype.UInt8{15}, Distance(5)},
+	{"multiple elements", hashtype.UInt8{10, 20, 30}, hashtype.UInt8{13, 25, 22}, Distance(16)},
+	{"different lengths", hashtype.UInt8{10, 20}, hashtype.UInt8{15, 25, 30}, Distance(10)},
+}
+
+func TestL1Uint8(t *testing.T) {
+	for _, tt := range l1Uint8Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := L1(tt.hash1, tt.hash2)
+			if !res.Equal(tt.out) {
+				t.Errorf("got %v, want %v", res, tt.out)
+			}
+		})
+	}
+}
+
+var l1Float64Tests = []struct {
+	name  string
+	hash1 hashtype.Float64
+	hash2 hashtype.Float64
+	out   Distance
+}{
+	{"same hashes", hashtype.Float64{1.5, 2.5, 3.5}, hashtype.Float64{1.5, 2.5, 3.5}, Distance(0)},
+	{"simple difference", hashtype.Float64{1.0, 2.0, 3.0}, hashtype.Float64{4.0, 6.0, 3.0}, Distance(7)},
+	{"negative values", hashtype.Float64{-1.0, -2.0}, hashtype.Float64{1.0, 2.0}, Distance(6)},
+}
+
+func TestL1Float64(t *testing.T) {
+	for _, tt := range l1Float64Tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := L1(tt.hash1, tt.hash2)
+			if !res.Equal(tt.out) {
+				t.Errorf("got %v, want %v", res, tt.out)
+			}
+		})
+	}
+}
+
+func ExampleL1() {
+	hash1 := hashtype.UInt8{60, 67, 86, 64, 58, 72, 68, 75}
+	hash2 := hashtype.UInt8{143, 213, 154, 170, 209, 125, 152, 173}
+
+	fmt.Println(L1(hash1, hash2))
+	// Output:
+	// 789
+}

--- a/similarity/weighted_hamming.go
+++ b/similarity/weighted_hamming.go
@@ -1,0 +1,38 @@
+package similarity
+
+import (
+	"errors"
+	"math/bits"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+)
+
+// ErrWeightLengthMismatch is reported when the weight slice length doesn't match the hash byte length.
+var ErrWeightLengthMismatch = errors.New("weight slice length must match number of hash bytes")
+
+// WeightedHamming calculates a weighted bit-level hamming distance between two binary hashes.
+// Each byte position is assigned a weight from the weights slice; the number of differing bits
+// at that position is multiplied by the corresponding weight.
+// The weights slice must have the same length as the shorter hash.
+func WeightedHamming(h1, h2 hashtype.Hash, weights []float64) (Distance, error) {
+	b1, ok := h1.(hashtype.Binary)
+	if !ok {
+		return 0, ErrNotBinaryHash
+	}
+	b2, ok := h2.(hashtype.Binary)
+	if !ok {
+		return 0, ErrNotBinaryHash
+	}
+	l := len(b1)
+	if len(b2) < l {
+		l = len(b2)
+	}
+	if len(weights) != l {
+		return 0, ErrWeightLengthMismatch
+	}
+	var dist float64
+	for i := 0; i < l; i++ {
+		dist += float64(bits.OnesCount8(b1[i]^b2[i])) * weights[i]
+	}
+	return Distance(dist), nil
+}

--- a/similarity/weighted_hamming_test.go
+++ b/similarity/weighted_hamming_test.go
@@ -1,0 +1,73 @@
+package similarity_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	. "github.com/ajdnik/imghash/v2/similarity"
+)
+
+var weightedHammingTests = []struct {
+	name     string
+	hash1    hashtype.Binary
+	hash2    hashtype.Binary
+	weights  []float64
+	distance Distance
+}{
+	{"uniform weights", hashtype.Binary{1}, hashtype.Binary{2}, []float64{1.0}, 2},
+	{"double weight", hashtype.Binary{1}, hashtype.Binary{2}, []float64{2.0}, 4},
+	{"zero weight", hashtype.Binary{1}, hashtype.Binary{2}, []float64{0.0}, 0},
+	{"two bytes uniform", hashtype.Binary{1, 1}, hashtype.Binary{2, 2}, []float64{1.0, 1.0}, 4},
+	{"two bytes varied", hashtype.Binary{1, 1}, hashtype.Binary{2, 2}, []float64{1.0, 3.0}, 8},
+	{"sample hashes", hashtype.Binary{15, 131, 192, 224, 192, 252, 255, 255}, hashtype.Binary{24, 60, 126, 126, 126, 126, 60, 0}, []float64{1, 1, 1, 1, 1, 1, 1, 1}, 42},
+	{"sample hashes weighted", hashtype.Binary{15, 131, 192, 224, 192, 252, 255, 255}, hashtype.Binary{24, 60, 126, 126, 126, 126, 60, 0}, []float64{2, 1, 1, 1, 1, 1, 1, 0.5}, 42},
+}
+
+func TestWeightedHamming(t *testing.T) {
+	for _, tt := range weightedHammingTests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res, err := WeightedHamming(tt.hash1, tt.hash2, tt.weights)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !res.Equal(tt.distance) {
+				t.Errorf("got %v, want %v", res, tt.distance)
+			}
+		})
+	}
+}
+
+func TestWeightedHamming_notBinary(t *testing.T) {
+	h1 := hashtype.UInt8{1, 2, 3}
+	h2 := hashtype.UInt8{4, 5, 6}
+	_, err := WeightedHamming(h1, h2, []float64{1, 1, 1})
+	if err != ErrNotBinaryHash {
+		t.Errorf("got %v, want %v", err, ErrNotBinaryHash)
+	}
+}
+
+func TestWeightedHamming_lengthMismatch(t *testing.T) {
+	h1 := hashtype.Binary{1, 2}
+	h2 := hashtype.Binary{3, 4}
+	_, err := WeightedHamming(h1, h2, []float64{1.0})
+	if err != ErrWeightLengthMismatch {
+		t.Errorf("got %v, want %v", err, ErrWeightLengthMismatch)
+	}
+}
+
+func ExampleWeightedHamming() {
+	hash1 := hashtype.Binary{15, 131, 192, 224, 192, 252, 255, 255}
+	hash2 := hashtype.Binary{24, 60, 126, 126, 126, 126, 60, 0}
+	weights := []float64{1, 1, 1, 1, 1, 1, 1, 1}
+
+	res, err := WeightedHamming(hash1, hash2, weights)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(res)
+	// Output:
+	// 42
+}

--- a/wavelet.go
+++ b/wavelet.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ajdnik/imghash/v2/hashtype"
 	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
 )
 
 // WHash is a perceptual hash based on the Haar wavelet transform.
@@ -102,6 +103,11 @@ func (wh WHash) computeHash(ll [][]float32, median float32) hashtype.Binary {
 		}
 	}
 	return hash
+}
+
+// Compare computes the Hamming distance between two WHash hashes.
+func (wh WHash) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	return similarity.Hamming(h1, h2)
 }
 
 // Ensure WHash satisfies the Hasher interface.

--- a/wavelet_test.go
+++ b/wavelet_test.go
@@ -105,7 +105,7 @@ func TestWHash_Distance(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
 			}
-			dist, err := similarity.Hamming(h1, h2)
+			dist, err := hash.Compare(h1, h2)
 			if err != nil {
 				t.Fatalf("failed to compute distance: %v", err)
 			}


### PR DESCRIPTION
## Summary

- Add four new similarity metrics to the `similarity` package: **Weighted Hamming**, **L1 (Manhattan)**, **Chi-Square**, and **Cosine** distance — each with full tests and examples.
- Add a `Compare` method to every hash algorithm that uses the recommended distance metric for that algorithm:
  - **Hamming**: Average, Difference, Median, BlockMean, MarrHildreth, WHash, PDQ, RASH
  - **Weighted Hamming**: PHash (with configurable per-byte weights via `WithWeights`)
  - **Chi-Square**: LBP
  - **Cosine**: HOGHash
  - **L1**: RadialVariance
  - **L2**: ColorMoment
- Update all distance tests to use the new `Compare` methods instead of calling `similarity.*` directly.
- Update README with `Compare` usage in every algorithm section, a full metric-per-algorithm table, and the complete list of available similarity functions.
- Update MIGRATION.md to recommend `Compare` as the preferred comparison approach.

## Type of Change

- [x] `feat` (new feature)
- [x] `docs` (documentation only)
- [x] `test` (tests only)

## Validation

```bash
go build ./...
go vet ./...
go test ./... -count=1
```

All 4 packages pass (imghash, hashtype, internal/imgproc, similarity).

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).