### PR TITLE
feat: Robust Hash Compare

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -137,6 +137,18 @@ h2, _ := pdq.Calculate(img2)
 dist, err := pdq.Compare(h1, h2)
 ```
 
+`Compare` input validation is strict:
+- hash values must be the expected concrete type for that algorithm
+- hash lengths must match
+- validation runs for both default metric and `WithDistance(...)` overrides
+
+Comparison sentinel errors:
+
+| Error | Meaning |
+|---|---|
+| `ErrIncompatibleHash` | hash type is incompatible for the selected compare path |
+| `ErrHashLengthMismatch` | hashes have different lengths |
+
 The generic top-level helper and the `similarity` sub-package remain available
 for callers who need a specific metric regardless of algorithm:
 
@@ -150,6 +162,9 @@ dist, err = similarity.Cosine(h1, h2)
 dist, err = similarity.L1(h1, h2)
 dist, err = similarity.WeightedHamming(h1, h2, weights)
 ```
+
+Note: `imghash.Compare` returns `ErrIncompatibleHash` when one hash is `Binary`
+and the other is not.
 
 ## 7. Optional: adopt new convenience helpers
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,11 @@ h2, _ := imghash.HashFile(pdq, "image2.png")
 dist, err := pdq.Compare(h1, h2)
 ```
 
+Algorithm `Compare` methods validate inputs before computing distance:
+- hash values must be the expected type for that algorithm
+- hash lengths must match
+- otherwise they return `ErrIncompatibleHash` or `ErrHashLengthMismatch`
+
 The default metric per algorithm:
 
 | Algorithm | Hash type | Default `Compare` metric |
@@ -373,6 +378,8 @@ Use `imghash.Compare(h1, h2)` for generic comparison based on hash type:
 ```go
 dist, err := imghash.Compare(h1, h2)
 ```
+
+`imghash.Compare` returns `ErrIncompatibleHash` when one hash is `Binary` and the other is not.
 
 ### Available metrics
 

--- a/average.go
+++ b/average.go
@@ -50,6 +50,9 @@ func (ah Average) Calculate(img image.Image) (hashtype.Hash, error) {
 
 // Compare computes the Hamming distance between two Average hashes.
 func (ah Average) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if ah.distFunc != nil {
 		return ah.distFunc(h1, h2)
 	}

--- a/blockmean.go
+++ b/blockmean.go
@@ -122,6 +122,9 @@ func (bh BlockMean) computeHash(means []float64, median float64) hashtype.Binary
 
 // Compare computes the Hamming distance between two BlockMean hashes.
 func (bh BlockMean) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if bh.distFunc != nil {
 		return bh.distFunc(h1, h2)
 	}

--- a/colormoment.go
+++ b/colormoment.go
@@ -75,6 +75,9 @@ func (ch ColorMoment) Calculate(img image.Image) (hashtype.Hash, error) {
 
 // Compare computes the L2 (Euclidean) distance between two ColorMoment hashes.
 func (ch ColorMoment) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateFloat64CompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if ch.distFunc != nil {
 		return ch.distFunc(h1, h2)
 	}

--- a/compare_validation.go
+++ b/compare_validation.go
@@ -1,0 +1,48 @@
+package imghash
+
+import "github.com/ajdnik/imghash/v2/hashtype"
+
+func validateBinaryCompareInputs(h1, h2 hashtype.Hash) error {
+	b1, ok := h1.(hashtype.Binary)
+	if !ok {
+		return ErrIncompatibleHash
+	}
+	b2, ok := h2.(hashtype.Binary)
+	if !ok {
+		return ErrIncompatibleHash
+	}
+	if len(b1) != len(b2) {
+		return ErrHashLengthMismatch
+	}
+	return nil
+}
+
+func validateUInt8CompareInputs(h1, h2 hashtype.Hash) error {
+	u1, ok := h1.(hashtype.UInt8)
+	if !ok {
+		return ErrIncompatibleHash
+	}
+	u2, ok := h2.(hashtype.UInt8)
+	if !ok {
+		return ErrIncompatibleHash
+	}
+	if len(u1) != len(u2) {
+		return ErrHashLengthMismatch
+	}
+	return nil
+}
+
+func validateFloat64CompareInputs(h1, h2 hashtype.Hash) error {
+	f1, ok := h1.(hashtype.Float64)
+	if !ok {
+		return ErrIncompatibleHash
+	}
+	f2, ok := h2.(hashtype.Float64)
+	if !ok {
+		return ErrIncompatibleHash
+	}
+	if len(f1) != len(f2) {
+		return ErrHashLengthMismatch
+	}
+	return nil
+}

--- a/convenience.go
+++ b/convenience.go
@@ -59,7 +59,12 @@ func Compare(h1, h2 hashtype.Hash, fn ...DistanceFunc) (similarity.Distance, err
 	if len(fn) > 0 && fn[0] != nil {
 		return fn[0](h1, h2)
 	}
-	if _, ok := h1.(hashtype.Binary); ok {
+	_, h1Binary := h1.(hashtype.Binary)
+	_, h2Binary := h2.(hashtype.Binary)
+	if h1Binary || h2Binary {
+		if !h1Binary || !h2Binary {
+			return 0, ErrIncompatibleHash
+		}
 		return similarity.Hamming(h1, h2)
 	}
 	return similarity.L2(h1, h2)

--- a/convenience_test.go
+++ b/convenience_test.go
@@ -70,11 +70,30 @@ func TestCompare_uint8(t *testing.T) {
 }
 
 func TestCompare_incompatible(t *testing.T) {
-	h1 := imghash.Binary{1, 2}
-	h2 := imghash.UInt8{3, 4}
-	_, err := imghash.Compare(h1, h2)
-	if err == nil {
-		t.Error("expected error for incompatible hash types")
+	tests := []struct {
+		name string
+		h1   imghash.Hash
+		h2   imghash.Hash
+	}{
+		{
+			name: "binary then uint8",
+			h1:   imghash.Binary{1, 2},
+			h2:   imghash.UInt8{3, 4},
+		},
+		{
+			name: "uint8 then binary",
+			h1:   imghash.UInt8{3, 4},
+			h2:   imghash.Binary{1, 2},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := imghash.Compare(tt.h1, tt.h2)
+			if !errors.Is(err, imghash.ErrIncompatibleHash) {
+				t.Fatalf("got %v, want %v", err, imghash.ErrIncompatibleHash)
+			}
+		})
 	}
 }
 

--- a/difference.go
+++ b/difference.go
@@ -62,6 +62,9 @@ func (dh Difference) computeHash(img *image.Gray) hashtype.Binary {
 
 // Compare computes the Hamming distance between two Difference hashes.
 func (dh Difference) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if dh.distFunc != nil {
 		return dh.distFunc(h1, h2)
 	}

--- a/distance_options_test.go
+++ b/distance_options_test.go
@@ -8,6 +8,190 @@ import (
 	"github.com/ajdnik/imghash/v2/hashtype"
 )
 
+type compareCase struct {
+	name              string
+	buildDefault      func() (imghash.Comparer, error)
+	buildWithDistance func(imghash.DistanceFunc) (imghash.Comparer, error)
+	valid1            hashtype.Hash
+	valid2            hashtype.Hash
+	invalidType1      hashtype.Hash
+	invalidType2      hashtype.Hash
+	invalidLen1       hashtype.Hash
+	invalidLen2       hashtype.Hash
+}
+
+var compareCases = []compareCase{
+	{
+		name:         "Average",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewAverage() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewAverage(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "Difference",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewDifference() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewDifference(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "Median",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewMedian() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewMedian(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "PHash",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewPHash() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewPHash(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "WHash",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewWHash() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewWHash(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "BlockMean",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewBlockMean() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewBlockMean(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "MarrHildreth",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewMarrHildreth() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewMarrHildreth(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "PDQ",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewPDQ() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewPDQ(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "RASH",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewRASH() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewRASH(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Binary{0x00, 0xFF},
+		valid2:       hashtype.Binary{0xFF, 0x00},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Binary{0x00},
+		invalidLen2:  hashtype.Binary{0x00, 0xFF},
+	},
+	{
+		name:         "RadialVariance",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewRadialVariance() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewRadialVariance(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.UInt8{1, 2, 3},
+		valid2:       hashtype.UInt8{3, 2, 1},
+		invalidType1: hashtype.Binary{0x00, 0xFF},
+		invalidType2: hashtype.Binary{0xFF, 0x00},
+		invalidLen1:  hashtype.UInt8{1, 2},
+		invalidLen2:  hashtype.UInt8{1, 2, 3},
+	},
+	{
+		name:         "LBP",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewLBP() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewLBP(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.UInt8{1, 2, 3},
+		valid2:       hashtype.UInt8{3, 2, 1},
+		invalidType1: hashtype.Binary{0x00, 0xFF},
+		invalidType2: hashtype.Binary{0xFF, 0x00},
+		invalidLen1:  hashtype.UInt8{1, 2},
+		invalidLen2:  hashtype.UInt8{1, 2, 3},
+	},
+	{
+		name:         "HOGHash",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewHOGHash() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewHOGHash(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.UInt8{1, 2, 3},
+		valid2:       hashtype.UInt8{3, 2, 1},
+		invalidType1: hashtype.Binary{0x00, 0xFF},
+		invalidType2: hashtype.Binary{0xFF, 0x00},
+		invalidLen1:  hashtype.UInt8{1, 2},
+		invalidLen2:  hashtype.UInt8{1, 2, 3},
+	},
+	{
+		name:         "ColorMoment",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewColorMoment() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewColorMoment(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Float64{1.0, 2.0},
+		valid2:       hashtype.Float64{3.0, 4.0},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Float64{1.0, 2.0},
+		invalidLen2:  hashtype.Float64{1.0, 2.0, 3.0},
+	},
+}
+
 func TestWithDistance_overrideAcrossHashers(t *testing.T) {
 	want := imghash.Distance(123.456)
 	calls := 0
@@ -16,59 +200,14 @@ func TestWithDistance_overrideAcrossHashers(t *testing.T) {
 		return want, nil
 	}
 
-	cases := []struct {
-		name  string
-		build func(imghash.DistanceFunc) (imghash.Comparer, error)
-	}{
-		{"Average", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewAverage(imghash.WithDistance(fn))
-		}},
-		{"Difference", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewDifference(imghash.WithDistance(fn))
-		}},
-		{"Median", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewMedian(imghash.WithDistance(fn))
-		}},
-		{"PHash", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewPHash(imghash.WithDistance(fn))
-		}},
-		{"WHash", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewWHash(imghash.WithDistance(fn))
-		}},
-		{"BlockMean", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewBlockMean(imghash.WithDistance(fn))
-		}},
-		{"MarrHildreth", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewMarrHildreth(imghash.WithDistance(fn))
-		}},
-		{"RadialVariance", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewRadialVariance(imghash.WithDistance(fn))
-		}},
-		{"ColorMoment", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewColorMoment(imghash.WithDistance(fn))
-		}},
-		{"LBP", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewLBP(imghash.WithDistance(fn))
-		}},
-		{"HOGHash", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewHOGHash(imghash.WithDistance(fn))
-		}},
-		{"PDQ", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewPDQ(imghash.WithDistance(fn))
-		}},
-		{"RASH", func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
-			return imghash.NewRASH(imghash.WithDistance(fn))
-		}},
-	}
-
-	for _, tc := range cases {
+	for _, tc := range compareCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmp, err := tc.build(custom)
+			cmp, err := tc.buildWithDistance(custom)
 			if err != nil {
 				t.Fatalf("failed to create hasher: %v", err)
 			}
 
-			got, err := cmp.Compare(hashtype.UInt8{1, 2, 3}, hashtype.UInt8{4, 5, 6})
+			got, err := cmp.Compare(tc.valid1, tc.valid2)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -78,8 +217,59 @@ func TestWithDistance_overrideAcrossHashers(t *testing.T) {
 		})
 	}
 
-	if calls != len(cases) {
-		t.Fatalf("custom distance called %d times, want %d", calls, len(cases))
+	if calls != len(compareCases) {
+		t.Fatalf("custom distance called %d times, want %d", calls, len(compareCases))
+	}
+}
+
+func TestWithDistance_validatesInputsBeforeOverride(t *testing.T) {
+	for _, tc := range compareCases {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			custom := func(_, _ hashtype.Hash) (imghash.Distance, error) {
+				calls++
+				return 1, nil
+			}
+			cmp, err := tc.buildWithDistance(custom)
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+
+			_, err = cmp.Compare(tc.invalidType1, tc.invalidType2)
+			if !errors.Is(err, imghash.ErrIncompatibleHash) {
+				t.Fatalf("type mismatch: got %v, want %v", err, imghash.ErrIncompatibleHash)
+			}
+
+			_, err = cmp.Compare(tc.invalidLen1, tc.invalidLen2)
+			if !errors.Is(err, imghash.ErrHashLengthMismatch) {
+				t.Fatalf("length mismatch: got %v, want %v", err, imghash.ErrHashLengthMismatch)
+			}
+
+			if calls != 0 {
+				t.Fatalf("custom distance called %d times, want 0", calls)
+			}
+		})
+	}
+}
+
+func TestCompare_defaultValidatesInputsAcrossHashers(t *testing.T) {
+	for _, tc := range compareCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmp, err := tc.buildDefault()
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+
+			_, err = cmp.Compare(tc.invalidType1, tc.invalidType2)
+			if !errors.Is(err, imghash.ErrIncompatibleHash) {
+				t.Fatalf("type mismatch: got %v, want %v", err, imghash.ErrIncompatibleHash)
+			}
+
+			_, err = cmp.Compare(tc.invalidLen1, tc.invalidLen2)
+			if !errors.Is(err, imghash.ErrHashLengthMismatch) {
+				t.Fatalf("length mismatch: got %v, want %v", err, imghash.ErrHashLengthMismatch)
+			}
+		})
 	}
 }
 

--- a/hoghash.go
+++ b/hoghash.go
@@ -163,6 +163,9 @@ func (hh HOGHash) computeHash(mag, orient []float64, w, h int) hashtype.UInt8 {
 
 // Compare computes the cosine distance between two HOGHash hashes.
 func (hh HOGHash) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateUInt8CompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if hh.distFunc != nil {
 		return hh.distFunc(h1, h2)
 	}

--- a/imghash.go
+++ b/imghash.go
@@ -74,6 +74,10 @@ type Distance = similarity.Distance
 // is used with incompatible hash types.
 var ErrIncompatibleHash = hashtype.ErrIncompatibleHash
 
+// ErrHashLengthMismatch is reported when two hashes of the expected type
+// have different lengths and cannot be compared safely.
+var ErrHashLengthMismatch = errors.New("imghash: hash lengths must match")
+
 // Constructor validation errors.
 var (
 	// ErrInvalidSize is returned when width or height is zero.

--- a/lbp.go
+++ b/lbp.go
@@ -134,6 +134,9 @@ func (lh LBP) computeHash(lbpImg []uint8, w, h int) hashtype.UInt8 {
 
 // Compare computes the chi-square distance between two LBP hashes.
 func (lh LBP) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateUInt8CompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if lh.distFunc != nil {
 		return lh.distFunc(h1, h2)
 	}

--- a/marrhildreth.go
+++ b/marrhildreth.go
@@ -150,6 +150,9 @@ func computeMarrHildrethKernel(alpha, level float64) [][]float32 {
 
 // Compare computes the Hamming distance between two MarrHildreth hashes.
 func (mhh MarrHildreth) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if mhh.distFunc != nil {
 		return mhh.distFunc(h1, h2)
 	}

--- a/medianhash.go
+++ b/medianhash.go
@@ -48,6 +48,9 @@ func (mh Median) Calculate(img image.Image) (hashtype.Hash, error) {
 
 // Compare computes the Hamming distance between two Median hashes.
 func (mh Median) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if mh.distFunc != nil {
 		return mh.distFunc(h1, h2)
 	}

--- a/pdq.go
+++ b/pdq.go
@@ -95,6 +95,9 @@ func (p PDQ) computeHash(block [][]float32, median float32) hashtype.Binary {
 
 // Compare computes the Hamming distance between two PDQ hashes.
 func (p PDQ) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if p.distFunc != nil {
 		return p.distFunc(h1, h2)
 	}

--- a/phash.go
+++ b/phash.go
@@ -115,6 +115,9 @@ func (ph PHash) compare(img [][]float32, val float32) [][]float32 {
 // Compare computes the weighted Hamming distance between two PHash hashes
 // using the per-byte weights configured on this hasher.
 func (ph PHash) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if ph.distFunc != nil {
 		return ph.distFunc(h1, h2)
 	}

--- a/radialvariance.go
+++ b/radialvariance.go
@@ -175,6 +175,9 @@ func (rv RadialVariance) computeHash(feat []float64) hashtype.UInt8 {
 
 // Compare computes the L1 (Manhattan) distance between two RadialVariance hashes.
 func (rv RadialVariance) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateUInt8CompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if rv.distFunc != nil {
 		return rv.distFunc(h1, h2)
 	}

--- a/rash.go
+++ b/rash.go
@@ -145,6 +145,9 @@ func (r RASH) computeHash(means []float64) hashtype.Binary {
 
 // Compare computes the Hamming distance between two RASH hashes.
 func (r RASH) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if r.distFunc != nil {
 		return r.distFunc(h1, h2)
 	}

--- a/wavelet.go
+++ b/wavelet.go
@@ -89,6 +89,9 @@ func (wh WHash) computeHash(ll [][]float32, median float32) hashtype.Binary {
 
 // Compare computes the Hamming distance between two WHash hashes.
 func (wh WHash) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
 	if wh.distFunc != nil {
 		return wh.distFunc(h1, h2)
 	}


### PR DESCRIPTION
## Summary

This PR hardens hash comparison behavior and removes silent success cases for incompatible inputs.

### What changed

- Fixed top-level `imghash.Compare(h1, h2)` so mixed `Binary` vs non-`Binary` hashes now consistently return `ErrIncompatibleHash` (independent of argument order).
- Added strict validation to all algorithm `Compare` methods before distance calculation:
  - expected concrete hash type is required
  - hash lengths must match
  - applies to both default metric and `WithDistance(...)` override path
- Added new sentinel error:
  - `ErrHashLengthMismatch` when same-type hashes differ in length
- Added shared validation helpers used by all hashers.
- Expanded/updated tests to cover:
  - symmetric incompatibility handling in top-level `Compare`
  - strict type/length validation across all hashers
  - validation happening before custom distance function execution
- Updated docs:
  - `README.md` (strict compare semantics + errors)
  - `MIGRATION.md` (migration notes for strict compare behavior)

## Related Issue

N/A

## Type of Change

- [ ] `feat` (new feature)
- [x] `fix` (bug fix)
- [x] `docs` (documentation only)
- [x] `test` (tests only)
- [ ] `chore` (maintenance/refactor/tooling)
- [x] Breaking change

## Validation

```bash
go test ./...
```

Result: all tests pass.

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [ ] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

### What changed

`Compare` is now strict for algorithm hashers:
- incompatible hash types return `ErrIncompatibleHash`
- differing hash lengths return `ErrHashLengthMismatch`
- validation runs before both default and custom (`WithDistance`) compare paths

Top-level `imghash.Compare` now also consistently errors on mixed `Binary`/non-`Binary` input pairs.

### Who is affected

Consumers relying on permissive/partial comparisons (e.g., min-length comparisons or cross-type comparisons that previously returned a numeric distance) may now receive explicit errors.

### How to migrate

- Ensure both hashes passed to a hasher `Compare` are:
  - the expected concrete hash type for that algorithm
  - exactly the same length
- Handle `ErrIncompatibleHash` and `ErrHashLengthMismatch` explicitly where needed.
