### PR TITLE
fix: Non Byte-aligned Hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ dist, err := rv.Compare(h1, h2) // L1 distance
 
 #### RASH (Rotation Aware Spatial Hash)
 
-Produces a 64-bit binary hash designed to be robust against image rotation. Compares using Hamming distance. This is a custom algorithm that combines concentric ring sampling for rotation invariance, a 1-D DCT for frequency compaction, and median thresholding for binarisation. The algorithm resizes the image, converts to grayscale, applies Gaussian blur, then samples pixel intensities on concentric rings around the image centre. Because ring-mean features are inherently rotation-invariant (rotating the image only permutes pixels within a ring, leaving its mean unchanged), the resulting hash stays stable under arbitrary rotations. Inspired by ring-partition hashing literature such as [Robust Image Hashing with Ring Partition and Invariant Vector Distance](https://ieeexplore.ieee.org/document/7368930) by Tang et al. and [Robust image hashing based on radial variance of pixels](https://www.researchgate.net/publication/4186555_Robust_image_hashing_based_on_radial_variance_of_pixels) by De Roover et al.
+Produces a binary hash (64 bits with default settings) designed to be robust against image rotation. Compares using Hamming distance. This is a custom algorithm that combines concentric ring sampling for rotation invariance, a 1-D DCT for frequency compaction, and median thresholding for binarisation. The algorithm resizes the image, converts to grayscale, applies Gaussian blur, then samples pixel intensities on concentric rings around the image centre. Because ring-mean features are inherently rotation-invariant (rotating the image only permutes pixels within a ring, leaving its mean unchanged), the resulting hash stays stable under arbitrary rotations. Inspired by ring-partition hashing literature such as [Robust Image Hashing with Ring Partition and Invariant Vector Distance](https://ieeexplore.ieee.org/document/7368930) by Tang et al. and [Robust image hashing based on radial variance of pixels](https://www.researchgate.net/publication/4186555_Robust_image_hashing_based_on_radial_variance_of_pixels) by De Roover et al.
 
 ```go
 rash, err := imghash.NewRASH()
@@ -328,6 +328,16 @@ dist, err := pdq.Compare(h1, h2) // Hamming distance
 | `WithInterpolation(i)` | `Bilinear` |
 
 The input size is fixed at 64×64 per the algorithm specification and is not configurable.
+
+### Binary hash size with custom options
+
+For binary hashers with configurable dimensions, the bit count may not be a multiple of 8. In that case:
+- the `Binary` value stores `ceil(bits/8)` bytes
+- unused bit positions in the last byte remain zero
+
+Examples:
+- `WithSize(3, 3)` for Average/Median/Difference/WHash yields 9 bits stored in 2 bytes
+- `RASH` uses `min(64, rings-1)` bits, so `WithRings(5)` yields 4 bits stored in 1 byte
 
 ## Similarity Metrics
 

--- a/average.go
+++ b/average.go
@@ -45,7 +45,7 @@ func (ah Average) Calculate(img image.Image) (hashtype.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
-	return thresholdHash(g, uint(math.Round(m))), nil
+	return thresholdHash(g, uint(math.Round(m)))
 }
 
 // Compare computes the Hamming distance between two Average hashes.

--- a/binary_alignment_test.go
+++ b/binary_alignment_test.go
@@ -1,0 +1,88 @@
+package imghash_test
+
+import (
+	"image"
+	"image/color"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+)
+
+func TestBinaryHashers_NonByteAlignedCapacity(t *testing.T) {
+	img := testGradientGray(21, 21)
+	tests := []struct {
+		name      string
+		wantBytes int
+		newHasher func() (imghash.Hasher, error)
+	}{
+		{
+			name:      "average 3x3",
+			wantBytes: 2,
+			newHasher: func() (imghash.Hasher, error) {
+				return imghash.NewAverage(imghash.WithSize(3, 3))
+			},
+		},
+		{
+			name:      "median 3x3",
+			wantBytes: 2,
+			newHasher: func() (imghash.Hasher, error) {
+				return imghash.NewMedian(imghash.WithSize(3, 3))
+			},
+		},
+		{
+			name:      "difference 3x3",
+			wantBytes: 2,
+			newHasher: func() (imghash.Hasher, error) {
+				return imghash.NewDifference(imghash.WithSize(3, 3))
+			},
+		},
+		{
+			name:      "wavelet 3x3",
+			wantBytes: 2,
+			newHasher: func() (imghash.Hasher, error) {
+				return imghash.NewWHash(imghash.WithSize(3, 3), imghash.WithLevel(1))
+			},
+		},
+		{
+			name:      "rash rings 5",
+			wantBytes: 1,
+			newHasher: func() (imghash.Hasher, error) {
+				return imghash.NewRASH(imghash.WithSize(32, 32), imghash.WithRings(5))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hasher, err := tt.newHasher()
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+
+			hash, err := hasher.Calculate(img)
+			if err != nil {
+				t.Fatalf("failed to calculate hash: %v", err)
+			}
+
+			bh, ok := hash.(hashtype.Binary)
+			if !ok {
+				t.Fatalf("expected binary hash, got %T", hash)
+			}
+
+			if got := bh.Len(); got != tt.wantBytes {
+				t.Fatalf("unexpected hash byte length: got %d, want %d", got, tt.wantBytes)
+			}
+		})
+	}
+}
+
+func testGradientGray(width, height int) *image.Gray {
+	img := image.NewGray(image.Rect(0, 0, width, height))
+	for y := 0; y < height; y++ {
+		for x := 0; x < width; x++ {
+			img.SetGray(x, y, color.Gray{Y: uint8((x*17 + y*13) % 256)})
+		}
+	}
+	return img
+}

--- a/difference.go
+++ b/difference.go
@@ -38,13 +38,12 @@ func (dh Difference) Calculate(img image.Image) (hashtype.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
-	return dh.computeHash(g), nil
+	return dh.computeHash(g)
 }
 
 // Computes the binary hash based on the gradients in the resized image.
-func (dh Difference) computeHash(img *image.Gray) hashtype.Binary {
-	size := dh.width * dh.height / 8
-	hash := make(hashtype.Binary, size)
+func (dh Difference) computeHash(img *image.Gray) (hashtype.Binary, error) {
+	hash := hashtype.NewBinary(dh.width * dh.height)
 	bnds := img.Bounds()
 	var c uint
 	for i := bnds.Min.Y; i < bnds.Max.Y; i++ {
@@ -52,12 +51,14 @@ func (dh Difference) computeHash(img *image.Gray) hashtype.Binary {
 			lft := img.GrayAt(j-1, i).Y
 			pix := img.GrayAt(j, i).Y
 			if pix > lft {
-				_ = hash.Set(c)
+				if err := hash.Set(c); err != nil {
+					return nil, err
+				}
 			}
 			c++
 		}
 	}
-	return hash
+	return hash, nil
 }
 
 // Compare computes the Hamming distance between two Difference hashes.

--- a/hashtype/binary.go
+++ b/hashtype/binary.go
@@ -16,6 +16,11 @@ import (
 // Binary represents a hash type where the smallest hash element is a bit.
 type Binary []byte
 
+// NewBinary allocates a binary hash with enough bytes to store bits.
+func NewBinary(bits uint) Binary {
+	return make(Binary, (bits+7)/8)
+}
+
 // String returns a string representation of the binary hash.
 // It is formatted as an array of bytes.
 func (h Binary) String() string {

--- a/hashtype/binary_test.go
+++ b/hashtype/binary_test.go
@@ -219,3 +219,25 @@ func TestBinary_ValueAt(t *testing.T) {
 		})
 	}
 }
+
+func TestNewBinary(t *testing.T) {
+	tests := []struct {
+		name string
+		bits uint
+		want int
+	}{
+		{"zero bits", 0, 0},
+		{"8 bits", 8, 1},
+		{"9 bits", 9, 2},
+		{"63 bits", 63, 8},
+		{"64 bits", 64, 8},
+		{"65 bits", 65, 9},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hashtype.NewBinary(tt.bits).Len(); got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}

--- a/medianhash.go
+++ b/medianhash.go
@@ -43,7 +43,7 @@ func (mh Median) Calculate(img image.Image) (hashtype.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
-	return thresholdHash(g, uint(math.Round(med))), nil
+	return thresholdHash(g, uint(math.Round(med)))
 }
 
 // Compare computes the Hamming distance between two Median hashes.

--- a/threshold.go
+++ b/threshold.go
@@ -8,18 +8,20 @@ import (
 
 // thresholdHash builds a binary hash by setting a bit for every pixel
 // whose intensity exceeds the given threshold. Used by Average and Median.
-func thresholdHash(img *image.Gray, threshold uint) hashtype.Binary {
+func thresholdHash(img *image.Gray, threshold uint) (hashtype.Binary, error) {
 	bnds := img.Bounds()
-	size := bnds.Dx() * bnds.Dy() / 8
-	hash := make(hashtype.Binary, size)
+	bits := uint(bnds.Dx() * bnds.Dy())
+	hash := hashtype.NewBinary(bits)
 	var c uint
 	for y := bnds.Min.Y; y < bnds.Max.Y; y++ {
 		for x := bnds.Min.X; x < bnds.Max.X; x++ {
 			if uint(img.GrayAt(x, y).Y) > threshold {
-				_ = hash.Set(c)
+				if err := hash.Set(c); err != nil {
+					return nil, err
+				}
 			}
 			c++
 		}
 	}
-	return hash
+	return hash, nil
 }

--- a/wavelet.go
+++ b/wavelet.go
@@ -57,7 +57,7 @@ func (wh WHash) Calculate(img image.Image) (hashtype.Hash, error) {
 
 	ll := wh.extractLL(mat)
 	med := wh.median(ll)
-	return wh.computeHash(ll, med), nil
+	return wh.computeHash(ll, med)
 }
 
 func (wh WHash) extractLL(mat [][]float32) [][]float32 {
@@ -73,18 +73,20 @@ func (wh WHash) median(mat [][]float32) float32 {
 	return imgproc.MedianF32(mat)
 }
 
-func (wh WHash) computeHash(ll [][]float32, median float32) hashtype.Binary {
-	hash := make(hashtype.Binary, wh.width*wh.height/8)
+func (wh WHash) computeHash(ll [][]float32, median float32) (hashtype.Binary, error) {
+	hash := hashtype.NewBinary(wh.width * wh.height)
 	var c uint
 	for _, row := range ll {
 		for _, v := range row {
 			if v > median {
-				_ = hash.Set(c)
+				if err := hash.Set(c); err != nil {
+					return nil, err
+				}
 			}
 			c++
 		}
 	}
-	return hash
+	return hash, nil
 }
 
 // Compare computes the Hamming distance between two WHash hashes.


### PR DESCRIPTION
## Summary

Fix silent bit truncation in several binary hash builders when configured bit counts are not byte-aligned.

### What changed

- Added `hashtype.NewBinary(bits)` to allocate binary hash storage using `ceil(bits/8)`.
- Updated affected hash builders to use rounded-up bit capacity instead of floor `/8` sizing:
  - threshold-based hashing (used by Average and Median)
  - Difference
  - WHash
  - RASH
- Stopped ignoring `hash.Set(...)` errors in those builders and propagated errors up through `Calculate`.
- Added a guard in RASH for very low-ring configurations that yield zero usable coefficients.

### Why

Previously, some custom configurations (for example non-8-multiple sizes or low `WithRings`) could allocate too few bytes, causing `Set` calls to go out of bounds. Those errors were ignored, which silently dropped bits and truncated hashes.

## Related Issue

Refs: review finding about non-byte-aligned binary hash truncation.

## Type of Change

- [x] `fix` (bug fix)
- [x] `docs` (documentation only)
- [x] `test` (tests only)
- [ ] `feat` (new feature)
- [ ] `chore` (maintenance/refactor/tooling)
- [ ] Breaking change

## Validation

```bash
go test ./...
```

Result: all tests passed.

## Checklist

- [x] I ran relevant checks locally (`go test ./...`).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [ ] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

None.
