### PR TITLE
feat: Rotation and RotationOverlap Variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ dist, err := bm.Compare(h1, h2) // Hamming distance
 | `WithBlockMeanMethod(m)` | `Direct` |
 
 Block mean methods: `Direct`, `Overlap`, `Rotation`, `RotationOverlap`.
+`Rotation` and `RotationOverlap` compute and concatenate hashes for 24 rotations (0 to 345 degrees in 15-degree steps), so the resulting hash is 24x larger than the corresponding non-rotational mode.
 
 #### Local Binary Pattern (LBP) Hash
 


### PR DESCRIPTION
## Summary

Implemented the missing BlockMean rotation functionality so the public `Rotation` and `RotationOverlap` modes are no longer aliases of non-rotational behavior.

- Added rotation-aware hashing for `Rotation` and `RotationOverlap`.
- Rotation modes now compute and concatenate hashes from 24 rotations (0 to 345 degrees, step 15).
- Added grayscale center-rotation helper with fixed output dimensions for per-angle hashing.
- Updated method comments/docs and removed stale TODO.
- Added tests that validate rotation segment behavior and expected output sizes.

## Related Issue

Fixes the integration trap where rotation modes were public/documented but not actually rotation-aware.

## Type of Change

- [x] `feat` (new feature)
- [x] `fix` (bug fix)
- [x] `docs` (documentation only)
- [x] `test` (tests only)
- [ ] `chore` (maintenance/refactor/tooling)
- [x] Breaking change

## Validation

Ran full test suite locally:

```bash
go test ./...
```

Result: all tests passed.

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

- what changed: `BlockMean` `Rotation` and `RotationOverlap` now produce truly rotation-aware hashes by concatenating 24 angle variants.
- who is affected: users persisting/comparing hashes produced with `Rotation` or `RotationOverlap`.
- how to migrate: regenerate stored hashes for those modes and update any expected hash-length assumptions and distance thresholds.
