### PR TITLE
fix: Weight Mutation

### DIFF
--- a/distance_options_test.go
+++ b/distance_options_test.go
@@ -304,3 +304,22 @@ func TestWithWeights_affectsPHashCompare(t *testing.T) {
 		t.Fatalf("got %v, want 4", got)
 	}
 }
+
+func TestWithWeights_clonesCallerSlice(t *testing.T) {
+	weights := []float64{2}
+	opt := imghash.WithWeights(weights)
+	weights[0] = 100
+
+	ph, err := imghash.NewPHash(opt)
+	if err != nil {
+		t.Fatalf("failed to create hasher: %v", err)
+	}
+
+	got, err := ph.Compare(hashtype.Binary{1}, hashtype.Binary{2})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !got.Equal(4) {
+		t.Fatalf("got %v, want 4", got)
+	}
+}

--- a/options.go
+++ b/options.go
@@ -169,7 +169,7 @@ func (o RingsOption) applyRASH(r *RASH) { r.rings = o.rings }
 // WeightsOption sets the per-byte weights for weighted distance.
 type WeightsOption struct{ weights []float64 }
 
-func (o WeightsOption) applyPHash(p *PHash) { p.weights = o.weights }
+func (o WeightsOption) applyPHash(p *PHash) { p.weights = append([]float64(nil), o.weights...) }
 
 // --- public constructors ---
 
@@ -262,7 +262,7 @@ func WithRings(rings int) RingsOption {
 // The slice length must match the number of hash bytes (8 for default PHash).
 // Applies to PHash.
 func WithWeights(weights []float64) WeightsOption {
-	return WeightsOption{weights}
+	return WeightsOption{append([]float64(nil), weights...)}
 }
 
 // WithDistance overrides the default distance function used by Compare.


### PR DESCRIPTION
## Summary

- Fixes a mutability bug in `WithWeights` for `PHash` by defensively copying the caller-provided `[]float64`.
- Prevents external slice mutations from changing `Compare` behavior after option construction.
- Adds regression coverage for caller-slice mutation.

## Related Issue

- N/A

## Type of Change

- [x] `fix` (bug fix)
- [x] `test` (tests only)

## Validation

```bash
go test ./...
```

Result: all tests passed.

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs/examples when needed.
- [ ] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

- None.
