### PR TITLE
fix: Invalid Interpolation Values

### DIFF
--- a/average.go
+++ b/average.go
@@ -28,8 +28,8 @@ func NewAverage(opts ...AverageOption) (Average, error) {
 	for _, o := range opts {
 		o.applyAverage(&a)
 	}
-	if a.width == 0 || a.height == 0 {
-		return Average{}, ErrInvalidSize
+	if err := a.validate(); err != nil {
+		return Average{}, err
 	}
 	return a, nil
 }

--- a/blockmean.go
+++ b/blockmean.go
@@ -57,8 +57,8 @@ func NewBlockMean(opts ...BlockMeanOption) (BlockMean, error) {
 	for _, o := range opts {
 		o.applyBlockMean(&b)
 	}
-	if b.width == 0 || b.height == 0 {
-		return BlockMean{}, ErrInvalidSize
+	if err := b.validate(); err != nil {
+		return BlockMean{}, err
 	}
 	if b.bWidth == 0 || b.bHeight == 0 {
 		return BlockMean{}, ErrInvalidBlockSize

--- a/colormoment.go
+++ b/colormoment.go
@@ -32,8 +32,8 @@ func NewColorMoment(opts ...ColorMomentOption) (ColorMoment, error) {
 	for _, o := range opts {
 		o.applyColorMoment(&c)
 	}
-	if c.width == 0 || c.height == 0 {
-		return ColorMoment{}, ErrInvalidSize
+	if err := c.validate(); err != nil {
+		return ColorMoment{}, err
 	}
 	if c.kernel <= 0 {
 		return ColorMoment{}, ErrInvalidKernelSize

--- a/difference.go
+++ b/difference.go
@@ -25,8 +25,8 @@ func NewDifference(opts ...DifferenceOption) (Difference, error) {
 	for _, o := range opts {
 		o.applyDifference(&d)
 	}
-	if d.width == 0 || d.height == 0 {
-		return Difference{}, ErrInvalidSize
+	if err := d.validate(); err != nil {
+		return Difference{}, err
 	}
 	return d, nil
 }

--- a/hoghash.go
+++ b/hoghash.go
@@ -38,8 +38,8 @@ func NewHOGHash(opts ...HOGHashOption) (HOGHash, error) {
 	for _, o := range opts {
 		o.applyHOGHash(&h)
 	}
-	if h.width == 0 || h.height == 0 {
-		return HOGHash{}, ErrInvalidSize
+	if err := h.validate(); err != nil {
+		return HOGHash{}, err
 	}
 	if h.cellSize == 0 {
 		return HOGHash{}, ErrInvalidCellSize

--- a/imghash.go
+++ b/imghash.go
@@ -82,6 +82,8 @@ var ErrHashLengthMismatch = errors.New("imghash: hash lengths must match")
 var (
 	// ErrInvalidSize is returned when width or height is zero.
 	ErrInvalidSize = errors.New("imghash: size dimensions must be greater than zero")
+	// ErrInvalidInterpolation is returned when an unsupported interpolation enum is supplied.
+	ErrInvalidInterpolation = errors.New("imghash: invalid interpolation method")
 	// ErrInvalidBlockSize is returned when block width or height is zero.
 	ErrInvalidBlockSize = errors.New("imghash: block size dimensions must be greater than zero")
 	// ErrInvalidAngles is returned when the number of projection angles is not positive.

--- a/internal/imgproc/resize.go
+++ b/internal/imgproc/resize.go
@@ -1,6 +1,7 @@
 package imgproc
 
 import (
+	"fmt"
 	"image"
 	"math"
 
@@ -69,7 +70,7 @@ func interpolatorFor(typ ResizeType) draw.Interpolator {
 	case Lanczos3:
 		return lanczos3
 	default:
-		return draw.NearestNeighbor
+		panic(fmt.Sprintf("imgproc: invalid resize type %d", typ))
 	}
 }
 

--- a/internal/imgproc/resize_test.go
+++ b/internal/imgproc/resize_test.go
@@ -59,13 +59,14 @@ func TestResize(t *testing.T) {
 	}
 }
 
-func TestResize_defaultInterpolator(t *testing.T) {
+func TestResize_invalidInterpolatorPanics(t *testing.T) {
 	img := makeTestImage(8, 8)
-	result := Resize(4, 4, img, ResizeType(99))
-	bounds := result.Bounds()
-	if bounds.Dx() != 4 || bounds.Dy() != 4 {
-		t.Errorf("got %dx%d, want 4x4", bounds.Dx(), bounds.Dy())
-	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic for invalid resize type")
+		}
+	}()
+	_ = Resize(4, 4, img, ResizeType(99))
 }
 
 func TestMitchellNetravaliAt(t *testing.T) {

--- a/interpolation.go
+++ b/interpolation.go
@@ -26,14 +26,28 @@ var interpolationNames = [...]string{
 	BilinearExact:     "BilinearExact",
 }
 
+func (i Interpolation) valid() bool {
+	return int(i) >= 0 && int(i) < len(interpolationNames)
+}
+
 // String returns the name of the interpolation method.
 func (i Interpolation) String() string {
-	if int(i) >= 0 && int(i) < len(interpolationNames) {
+	if i.valid() {
 		return interpolationNames[i]
 	}
 	return "Unknown"
 }
 
+func (i Interpolation) validate() error {
+	if !i.valid() {
+		return ErrInvalidInterpolation
+	}
+	return nil
+}
+
 func (i Interpolation) resizeType() imgproc.ResizeType {
+	if !i.valid() {
+		panic("imghash: invalid interpolation value")
+	}
 	return imgproc.ResizeType(i)
 }

--- a/interpolation_validation_test.go
+++ b/interpolation_validation_test.go
@@ -1,0 +1,110 @@
+package imghash_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2"
+)
+
+func TestWithInterpolation_invalidValue(t *testing.T) {
+	invalid := imghash.Interpolation(99)
+	tests := []struct {
+		name string
+		new  func() error
+	}{
+		{
+			name: "Average",
+			new: func() error {
+				_, err := imghash.NewAverage(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "Difference",
+			new: func() error {
+				_, err := imghash.NewDifference(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "Median",
+			new: func() error {
+				_, err := imghash.NewMedian(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "PHash",
+			new: func() error {
+				_, err := imghash.NewPHash(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "BlockMean",
+			new: func() error {
+				_, err := imghash.NewBlockMean(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "MarrHildreth",
+			new: func() error {
+				_, err := imghash.NewMarrHildreth(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "ColorMoment",
+			new: func() error {
+				_, err := imghash.NewColorMoment(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "WHash",
+			new: func() error {
+				_, err := imghash.NewWHash(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "LBP",
+			new: func() error {
+				_, err := imghash.NewLBP(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "HOGHash",
+			new: func() error {
+				_, err := imghash.NewHOGHash(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "PDQ",
+			new: func() error {
+				_, err := imghash.NewPDQ(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
+			name: "RASH",
+			new: func() error {
+				_, err := imghash.NewRASH(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.new()
+			if !errors.Is(err, imghash.ErrInvalidInterpolation) {
+				t.Fatalf("expected ErrInvalidInterpolation, got %v", err)
+			}
+		})
+	}
+}

--- a/lbp.go
+++ b/lbp.go
@@ -37,8 +37,8 @@ func NewLBP(opts ...LBPOption) (LBP, error) {
 	for _, o := range opts {
 		o.applyLBP(&l)
 	}
-	if l.width == 0 || l.height == 0 {
-		return LBP{}, ErrInvalidSize
+	if err := l.validate(); err != nil {
+		return LBP{}, err
 	}
 	if l.gridX == 0 || l.gridY == 0 {
 		return LBP{}, ErrInvalidGridSize

--- a/marrhildreth.go
+++ b/marrhildreth.go
@@ -48,8 +48,8 @@ func NewMarrHildreth(opts ...MarrHildrethOption) (MarrHildreth, error) {
 	for _, o := range opts {
 		o.applyMarrHildreth(&mh)
 	}
-	if mh.width == 0 || mh.height == 0 {
-		return MarrHildreth{}, ErrInvalidSize
+	if err := mh.validate(); err != nil {
+		return MarrHildreth{}, err
 	}
 	if mh.scale <= 0 {
 		return MarrHildreth{}, ErrInvalidScale

--- a/medianhash.go
+++ b/medianhash.go
@@ -26,8 +26,8 @@ func NewMedian(opts ...MedianOption) (Median, error) {
 	for _, o := range opts {
 		o.applyMedian(&m)
 	}
-	if m.width == 0 || m.height == 0 {
-		return Median{}, ErrInvalidSize
+	if err := m.validate(); err != nil {
+		return Median{}, err
 	}
 	return m, nil
 }

--- a/options.go
+++ b/options.go
@@ -8,6 +8,13 @@ type baseConfig struct {
 	interp        Interpolation
 }
 
+func (b baseConfig) validate() error {
+	if b.width == 0 || b.height == 0 {
+		return ErrInvalidSize
+	}
+	return b.interp.validate()
+}
+
 // Algorithm-specific option interfaces. Each uses an unexported method
 // so that only option types in this package can implement them.
 

--- a/pdq.go
+++ b/pdq.go
@@ -45,6 +45,9 @@ func NewPDQ(opts ...PDQOption) (PDQ, error) {
 	for _, o := range opts {
 		o.applyPDQ(&p)
 	}
+	if err := p.interp.validate(); err != nil {
+		return PDQ{}, err
+	}
 	return p, nil
 }
 

--- a/phash.go
+++ b/phash.go
@@ -32,8 +32,8 @@ func NewPHash(opts ...PHashOption) (PHash, error) {
 	for _, o := range opts {
 		o.applyPHash(&p)
 	}
-	if p.width == 0 || p.height == 0 {
-		return PHash{}, ErrInvalidSize
+	if err := p.validate(); err != nil {
+		return PHash{}, err
 	}
 	if p.weights == nil {
 		p.weights = make([]float64, dctCoefSize)

--- a/rash.go
+++ b/rash.go
@@ -42,8 +42,8 @@ func NewRASH(opts ...RASHOption) (RASH, error) {
 	for _, o := range opts {
 		o.applyRASH(&r)
 	}
-	if r.width == 0 || r.height == 0 {
-		return RASH{}, ErrInvalidSize
+	if err := r.validate(); err != nil {
+		return RASH{}, err
 	}
 	if r.sigma < 0 {
 		return RASH{}, ErrInvalidSigma

--- a/wavelet.go
+++ b/wavelet.go
@@ -30,8 +30,8 @@ func NewWHash(opts ...WHashOption) (WHash, error) {
 	for _, o := range opts {
 		o.applyWHash(&w)
 	}
-	if w.width == 0 || w.height == 0 {
-		return WHash{}, ErrInvalidSize
+	if err := w.validate(); err != nil {
+		return WHash{}, err
 	}
 	if w.level <= 0 {
 		return WHash{}, ErrInvalidLevel


### PR DESCRIPTION
## Summary

Fixes invalid interpolation handling so bad enum values are rejected explicitly instead of silently degrading to nearest-neighbor.

Changes included:
- Added `ErrInvalidInterpolation` and interpolation validation helpers.
- Added constructor-time validation for interpolation across all hashers that accept `WithInterpolation` (including `PDQ`).
- Removed internal silent fallback in `internal/imgproc/resize.go`; invalid `ResizeType` now panics.
- Added tests to verify invalid interpolation returns `ErrInvalidInterpolation` for all relevant constructors.
- Updated internal resize test to assert panic on invalid resize type.
- Addressed lint by using promoted embedded-method calls (`x.validate()`) in constructors.

## Related Issue

Refs: medium review item about silent interpolation fallback (`interpolation.go:37`, `internal/imgproc/resize.go:57`, `internal/imgproc/resize.go:71`).

## Type of Change

- [ ] `feat` (new feature)
- [x] `fix` (bug fix)
- [ ] `docs` (documentation only)
- [x] `test` (tests only)
- [x] `chore` (maintenance/refactor/tooling)
- [ ] Breaking change

## Validation

```bash
make lint
# golangci-lint run ./...
# 0 issues.

go test ./...
# ok github.com/ajdnik/imghash/v2
# ok github.com/ajdnik/imghash/v2/hashtype
# ok github.com/ajdnik/imghash/v2/internal/imgproc
# ok github.com/ajdnik/imghash/v2/similarity
```

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [ ] I updated docs/examples when needed.
- [ ] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

Not a breaking API change. Behavior change: invalid interpolation enum values now fail fast (`ErrInvalidInterpolation`) instead of silently using nearest-neighbor.
