### PR TITLE
fix: Restructure Options

### DIFF
--- a/options.go
+++ b/options.go
@@ -57,219 +57,323 @@ type PDQOption interface{ applyPDQ(*PDQ) }
 // RASHOption configures the RASH hash algorithm.
 type RASHOption interface{ applyRASH(*RASH) }
 
+// Option interfaces returned by With* constructors.
+// Concrete implementations are intentionally unexported.
+
 // DistanceOption overrides the comparison function used by Compare.
-type DistanceOption struct{ fn DistanceFunc }
+type DistanceOption interface {
+	AverageOption
+	DifferenceOption
+	MedianOption
+	PHashOption
+	BlockMeanOption
+	MarrHildrethOption
+	RadialVarianceOption
+	ColorMomentOption
+	WHashOption
+	LBPOption
+	HOGHashOption
+	PDQOption
+	RASHOption
+}
 
-func (o DistanceOption) applyAverage(a *Average)               { a.distFunc = o.fn }
-func (o DistanceOption) applyDifference(d *Difference)         { d.distFunc = o.fn }
-func (o DistanceOption) applyMedian(m *Median)                 { m.distFunc = o.fn }
-func (o DistanceOption) applyPHash(p *PHash)                   { p.distFunc = o.fn }
-func (o DistanceOption) applyBlockMean(b *BlockMean)           { b.distFunc = o.fn }
-func (o DistanceOption) applyMarrHildreth(m *MarrHildreth)     { m.distFunc = o.fn }
-func (o DistanceOption) applyRadialVariance(r *RadialVariance) { r.distFunc = o.fn }
-func (o DistanceOption) applyColorMoment(c *ColorMoment)       { c.distFunc = o.fn }
-func (o DistanceOption) applyWHash(w *WHash)                   { w.distFunc = o.fn }
-func (o DistanceOption) applyLBP(l *LBP)                       { l.distFunc = o.fn }
-func (o DistanceOption) applyHOGHash(h *HOGHash)               { h.distFunc = o.fn }
-func (o DistanceOption) applyPDQ(p *PDQ)                       { p.distFunc = o.fn }
-func (o DistanceOption) applyRASH(r *RASH)                     { r.distFunc = o.fn }
+type distanceOption struct{ fn DistanceFunc }
 
-// --- concrete option types ---
+func (o distanceOption) applyAverage(a *Average)               { a.distFunc = o.fn }
+func (o distanceOption) applyDifference(d *Difference)         { d.distFunc = o.fn }
+func (o distanceOption) applyMedian(m *Median)                 { m.distFunc = o.fn }
+func (o distanceOption) applyPHash(p *PHash)                   { p.distFunc = o.fn }
+func (o distanceOption) applyBlockMean(b *BlockMean)           { b.distFunc = o.fn }
+func (o distanceOption) applyMarrHildreth(m *MarrHildreth)     { m.distFunc = o.fn }
+func (o distanceOption) applyRadialVariance(r *RadialVariance) { r.distFunc = o.fn }
+func (o distanceOption) applyColorMoment(c *ColorMoment)       { c.distFunc = o.fn }
+func (o distanceOption) applyWHash(w *WHash)                   { w.distFunc = o.fn }
+func (o distanceOption) applyLBP(l *LBP)                       { l.distFunc = o.fn }
+func (o distanceOption) applyHOGHash(h *HOGHash)               { h.distFunc = o.fn }
+func (o distanceOption) applyPDQ(p *PDQ)                       { p.distFunc = o.fn }
+func (o distanceOption) applyRASH(r *RASH)                     { r.distFunc = o.fn }
+
+// --- concrete option implementations ---
 
 // SizeOption sets width and height for hash computation.
-type SizeOption struct{ width, height uint }
+type SizeOption interface {
+	AverageOption
+	DifferenceOption
+	MedianOption
+	PHashOption
+	BlockMeanOption
+	MarrHildrethOption
+	ColorMomentOption
+	WHashOption
+	LBPOption
+	HOGHashOption
+	RASHOption
+}
 
-func (o SizeOption) applyBase(b *baseConfig)           { b.width, b.height = o.width, o.height }
-func (o SizeOption) applyAverage(a *Average)           { o.applyBase(&a.baseConfig) }
-func (o SizeOption) applyDifference(d *Difference)     { o.applyBase(&d.baseConfig) }
-func (o SizeOption) applyMedian(m *Median)             { o.applyBase(&m.baseConfig) }
-func (o SizeOption) applyPHash(p *PHash)               { o.applyBase(&p.baseConfig) }
-func (o SizeOption) applyBlockMean(b *BlockMean)       { o.applyBase(&b.baseConfig) }
-func (o SizeOption) applyMarrHildreth(m *MarrHildreth) { o.applyBase(&m.baseConfig) }
-func (o SizeOption) applyColorMoment(c *ColorMoment)   { o.applyBase(&c.baseConfig) }
-func (o SizeOption) applyWHash(w *WHash)               { o.applyBase(&w.baseConfig) }
-func (o SizeOption) applyLBP(l *LBP)                   { o.applyBase(&l.baseConfig) }
-func (o SizeOption) applyHOGHash(h *HOGHash)           { o.applyBase(&h.baseConfig) }
-func (o SizeOption) applyRASH(r *RASH)                 { o.applyBase(&r.baseConfig) }
+type sizeOption struct{ width, height uint }
+
+func (o sizeOption) applyBase(b *baseConfig)           { b.width, b.height = o.width, o.height }
+func (o sizeOption) applyAverage(a *Average)           { o.applyBase(&a.baseConfig) }
+func (o sizeOption) applyDifference(d *Difference)     { o.applyBase(&d.baseConfig) }
+func (o sizeOption) applyMedian(m *Median)             { o.applyBase(&m.baseConfig) }
+func (o sizeOption) applyPHash(p *PHash)               { o.applyBase(&p.baseConfig) }
+func (o sizeOption) applyBlockMean(b *BlockMean)       { o.applyBase(&b.baseConfig) }
+func (o sizeOption) applyMarrHildreth(m *MarrHildreth) { o.applyBase(&m.baseConfig) }
+func (o sizeOption) applyColorMoment(c *ColorMoment)   { o.applyBase(&c.baseConfig) }
+func (o sizeOption) applyWHash(w *WHash)               { o.applyBase(&w.baseConfig) }
+func (o sizeOption) applyLBP(l *LBP)                   { o.applyBase(&l.baseConfig) }
+func (o sizeOption) applyHOGHash(h *HOGHash)           { o.applyBase(&h.baseConfig) }
+func (o sizeOption) applyRASH(r *RASH)                 { o.applyBase(&r.baseConfig) }
 
 // InterpolationOption sets the resize interpolation method.
-type InterpolationOption struct{ interp Interpolation }
+type InterpolationOption interface {
+	AverageOption
+	DifferenceOption
+	MedianOption
+	PHashOption
+	BlockMeanOption
+	MarrHildrethOption
+	ColorMomentOption
+	WHashOption
+	LBPOption
+	HOGHashOption
+	PDQOption
+	RASHOption
+}
 
-func (o InterpolationOption) applyBase(b *baseConfig)           { b.interp = o.interp }
-func (o InterpolationOption) applyAverage(a *Average)           { o.applyBase(&a.baseConfig) }
-func (o InterpolationOption) applyDifference(d *Difference)     { o.applyBase(&d.baseConfig) }
-func (o InterpolationOption) applyMedian(m *Median)             { o.applyBase(&m.baseConfig) }
-func (o InterpolationOption) applyPHash(p *PHash)               { o.applyBase(&p.baseConfig) }
-func (o InterpolationOption) applyBlockMean(b *BlockMean)       { o.applyBase(&b.baseConfig) }
-func (o InterpolationOption) applyMarrHildreth(m *MarrHildreth) { o.applyBase(&m.baseConfig) }
-func (o InterpolationOption) applyColorMoment(c *ColorMoment)   { o.applyBase(&c.baseConfig) }
-func (o InterpolationOption) applyWHash(w *WHash)               { o.applyBase(&w.baseConfig) }
-func (o InterpolationOption) applyLBP(l *LBP)                   { o.applyBase(&l.baseConfig) }
-func (o InterpolationOption) applyHOGHash(h *HOGHash)           { o.applyBase(&h.baseConfig) }
-func (o InterpolationOption) applyPDQ(p *PDQ)                   { p.interp = o.interp }
-func (o InterpolationOption) applyRASH(r *RASH)                 { o.applyBase(&r.baseConfig) }
+type interpolationOption struct{ interp Interpolation }
+
+func (o interpolationOption) applyBase(b *baseConfig)           { b.interp = o.interp }
+func (o interpolationOption) applyAverage(a *Average)           { o.applyBase(&a.baseConfig) }
+func (o interpolationOption) applyDifference(d *Difference)     { o.applyBase(&d.baseConfig) }
+func (o interpolationOption) applyMedian(m *Median)             { o.applyBase(&m.baseConfig) }
+func (o interpolationOption) applyPHash(p *PHash)               { o.applyBase(&p.baseConfig) }
+func (o interpolationOption) applyBlockMean(b *BlockMean)       { o.applyBase(&b.baseConfig) }
+func (o interpolationOption) applyMarrHildreth(m *MarrHildreth) { o.applyBase(&m.baseConfig) }
+func (o interpolationOption) applyColorMoment(c *ColorMoment)   { o.applyBase(&c.baseConfig) }
+func (o interpolationOption) applyWHash(w *WHash)               { o.applyBase(&w.baseConfig) }
+func (o interpolationOption) applyLBP(l *LBP)                   { o.applyBase(&l.baseConfig) }
+func (o interpolationOption) applyHOGHash(h *HOGHash)           { o.applyBase(&h.baseConfig) }
+func (o interpolationOption) applyPDQ(p *PDQ)                   { p.interp = o.interp }
+func (o interpolationOption) applyRASH(r *RASH)                 { o.applyBase(&r.baseConfig) }
 
 // KernelSizeOption sets the Gaussian kernel size.
-type KernelSizeOption struct{ size int }
+type KernelSizeOption interface {
+	MarrHildrethOption
+	ColorMomentOption
+}
 
-func (o KernelSizeOption) applyMarrHildreth(m *MarrHildreth) { m.kernel = o.size }
-func (o KernelSizeOption) applyColorMoment(c *ColorMoment)   { c.kernel = o.size }
+type kernelSizeOption struct{ size int }
+
+func (o kernelSizeOption) applyMarrHildreth(m *MarrHildreth) { m.kernel = o.size }
+func (o kernelSizeOption) applyColorMoment(c *ColorMoment)   { c.kernel = o.size }
 
 // SigmaOption sets the Gaussian standard deviation.
-type SigmaOption struct{ sigma float64 }
+type SigmaOption interface {
+	MarrHildrethOption
+	ColorMomentOption
+	RadialVarianceOption
+	RASHOption
+}
 
-func (o SigmaOption) applyMarrHildreth(m *MarrHildreth)     { m.sigma = o.sigma }
-func (o SigmaOption) applyColorMoment(c *ColorMoment)       { c.sigma = o.sigma }
-func (o SigmaOption) applyRadialVariance(r *RadialVariance) { r.sigma = o.sigma }
-func (o SigmaOption) applyRASH(r *RASH)                     { r.sigma = o.sigma }
+type sigmaOption struct{ sigma float64 }
+
+func (o sigmaOption) applyMarrHildreth(m *MarrHildreth)     { m.sigma = o.sigma }
+func (o sigmaOption) applyColorMoment(c *ColorMoment)       { c.sigma = o.sigma }
+func (o sigmaOption) applyRadialVariance(r *RadialVariance) { r.sigma = o.sigma }
+func (o sigmaOption) applyRASH(r *RASH)                     { r.sigma = o.sigma }
 
 // BlockSizeOption sets block dimensions for BlockMean.
-type BlockSizeOption struct{ width, height uint }
+type BlockSizeOption interface {
+	BlockMeanOption
+}
 
-func (o BlockSizeOption) applyBlockMean(b *BlockMean) { b.bWidth, b.bHeight = o.width, o.height }
+type blockSizeOption struct{ width, height uint }
+
+func (o blockSizeOption) applyBlockMean(b *BlockMean) { b.bWidth, b.bHeight = o.width, o.height }
 
 // BlockMeanMethodOption sets the block construction method.
-type BlockMeanMethodOption struct{ method BlockMeanMethod }
+type BlockMeanMethodOption interface {
+	BlockMeanOption
+}
 
-func (o BlockMeanMethodOption) applyBlockMean(b *BlockMean) { b.method = o.method }
+type blockMeanMethodOption struct{ method BlockMeanMethod }
+
+func (o blockMeanMethodOption) applyBlockMean(b *BlockMean) { b.method = o.method }
 
 // ScaleOption sets the scale parameter.
-type ScaleOption struct{ scale float64 }
+type ScaleOption interface {
+	MarrHildrethOption
+}
 
-func (o ScaleOption) applyMarrHildreth(m *MarrHildreth) { m.scale = o.scale }
+type scaleOption struct{ scale float64 }
+
+func (o scaleOption) applyMarrHildreth(m *MarrHildreth) { m.scale = o.scale }
 
 // AlphaOption sets the alpha parameter.
-type AlphaOption struct{ alpha float64 }
+type AlphaOption interface {
+	MarrHildrethOption
+}
 
-func (o AlphaOption) applyMarrHildreth(m *MarrHildreth) { m.alpha = o.alpha }
+type alphaOption struct{ alpha float64 }
+
+func (o alphaOption) applyMarrHildreth(m *MarrHildreth) { m.alpha = o.alpha }
 
 // AnglesOption sets the number of projection angles.
-type AnglesOption struct{ angles int }
+type AnglesOption interface {
+	RadialVarianceOption
+}
 
-func (o AnglesOption) applyRadialVariance(r *RadialVariance) { r.angles = o.angles }
+type anglesOption struct{ angles int }
+
+func (o anglesOption) applyRadialVariance(r *RadialVariance) { r.angles = o.angles }
 
 // LevelOption sets the wavelet decomposition level.
-type LevelOption struct{ level int }
+type LevelOption interface {
+	WHashOption
+}
 
-func (o LevelOption) applyWHash(w *WHash) { w.level = o.level }
+type levelOption struct{ level int }
+
+func (o levelOption) applyWHash(w *WHash) { w.level = o.level }
 
 // GridSizeOption sets the grid cell count for spatial histograms.
-type GridSizeOption struct{ x, y uint }
+type GridSizeOption interface {
+	LBPOption
+}
 
-func (o GridSizeOption) applyLBP(l *LBP) { l.gridX, l.gridY = o.x, o.y }
+type gridSizeOption struct{ x, y uint }
+
+func (o gridSizeOption) applyLBP(l *LBP) { l.gridX, l.gridY = o.x, o.y }
 
 // CellSizeOption sets the cell size in pixels for HOG computation.
-type CellSizeOption struct{ size uint }
+type CellSizeOption interface {
+	HOGHashOption
+}
 
-func (o CellSizeOption) applyHOGHash(h *HOGHash) { h.cellSize = o.size }
+type cellSizeOption struct{ size uint }
+
+func (o cellSizeOption) applyHOGHash(h *HOGHash) { h.cellSize = o.size }
 
 // NumBinsOption sets the number of orientation histogram bins.
-type NumBinsOption struct{ bins uint }
+type NumBinsOption interface {
+	HOGHashOption
+}
 
-func (o NumBinsOption) applyHOGHash(h *HOGHash) { h.numBins = o.bins }
+type numBinsOption struct{ bins uint }
+
+func (o numBinsOption) applyHOGHash(h *HOGHash) { h.numBins = o.bins }
 
 // RingsOption sets the number of concentric rings.
-type RingsOption struct{ rings int }
+type RingsOption interface {
+	RASHOption
+}
 
-func (o RingsOption) applyRASH(r *RASH) { r.rings = o.rings }
+type ringsOption struct{ rings int }
+
+func (o ringsOption) applyRASH(r *RASH) { r.rings = o.rings }
 
 // WeightsOption sets the per-byte weights for weighted distance.
-type WeightsOption struct{ weights []float64 }
+type WeightsOption interface {
+	PHashOption
+}
 
-func (o WeightsOption) applyPHash(p *PHash) { p.weights = append([]float64(nil), o.weights...) }
+type weightsOption struct{ weights []float64 }
+
+func (o weightsOption) applyPHash(p *PHash) { p.weights = append([]float64(nil), o.weights...) }
 
 // --- public constructors ---
 
 // WithSize sets the resize dimensions used during hash computation.
 // Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, HOGHash, and RASH.
 func WithSize(width, height uint) SizeOption {
-	return SizeOption{width, height}
+	return sizeOption{width, height}
 }
 
 // WithInterpolation sets the resize interpolation method.
 // Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, HOGHash, PDQ, and RASH.
 func WithInterpolation(interp Interpolation) InterpolationOption {
-	return InterpolationOption{interp}
+	return interpolationOption{interp}
 }
 
 // WithKernelSize sets the Gaussian kernel size.
 // Applies to MarrHildreth and ColorMoment.
 func WithKernelSize(size int) KernelSizeOption {
-	return KernelSizeOption{size}
+	return kernelSizeOption{size}
 }
 
 // WithSigma sets the Gaussian kernel standard deviation.
 // Applies to MarrHildreth, ColorMoment, RadialVariance, and RASH.
 func WithSigma(sigma float64) SigmaOption {
-	return SigmaOption{sigma}
+	return sigmaOption{sigma}
 }
 
 // WithBlockSize sets the block dimensions for block mean hashing.
 // Applies to BlockMean.
 func WithBlockSize(width, height uint) BlockSizeOption {
-	return BlockSizeOption{width, height}
+	return blockSizeOption{width, height}
 }
 
 // WithBlockMeanMethod sets the block construction method.
 // Applies to BlockMean.
 func WithBlockMeanMethod(method BlockMeanMethod) BlockMeanMethodOption {
-	return BlockMeanMethodOption{method}
+	return blockMeanMethodOption{method}
 }
 
 // WithScale sets the scale parameter.
 // Applies to MarrHildreth.
 func WithScale(scale float64) ScaleOption {
-	return ScaleOption{scale}
+	return scaleOption{scale}
 }
 
 // WithAlpha sets the alpha parameter.
 // Applies to MarrHildreth.
 func WithAlpha(alpha float64) AlphaOption {
-	return AlphaOption{alpha}
+	return alphaOption{alpha}
 }
 
 // WithAngles sets the number of projection angles.
 // Applies to RadialVariance.
 func WithAngles(angles int) AnglesOption {
-	return AnglesOption{angles}
+	return anglesOption{angles}
 }
 
 // WithLevel sets the number of Haar wavelet decomposition levels.
 // Applies to WHash.
 func WithLevel(level int) LevelOption {
-	return LevelOption{level}
+	return levelOption{level}
 }
 
 // WithGridSize sets the number of grid cells used to divide the image for
 // spatial histogram computation.
 // Applies to LBP.
 func WithGridSize(x, y uint) GridSizeOption {
-	return GridSizeOption{x, y}
+	return gridSizeOption{x, y}
 }
 
 // WithCellSize sets the cell size in pixels (square cells) for HOG computation.
 // Applies to HOGHash.
 func WithCellSize(size uint) CellSizeOption {
-	return CellSizeOption{size}
+	return cellSizeOption{size}
 }
 
 // WithNumBins sets the number of orientation histogram bins.
 // Applies to HOGHash.
 func WithNumBins(bins uint) NumBinsOption {
-	return NumBinsOption{bins}
+	return numBinsOption{bins}
 }
 
 // WithRings sets the number of concentric rings used for spatial sampling.
 // Applies to RASH.
 func WithRings(rings int) RingsOption {
-	return RingsOption{rings}
+	return ringsOption{rings}
 }
 
 // WithWeights sets the per-byte weights used for weighted Hamming distance.
 // The slice length must match the number of hash bytes (8 for default PHash).
 // Applies to PHash.
 func WithWeights(weights []float64) WeightsOption {
-	return WeightsOption{append([]float64(nil), weights...)}
+	return weightsOption{append([]float64(nil), weights...)}
 }
 
 // WithDistance overrides the default distance function used by Compare.
@@ -277,5 +381,5 @@ func WithWeights(weights []float64) WeightsOption {
 // ChiSquare, PCC) satisfy DistanceFunc and can be passed directly.
 // Applies to all algorithms.
 func WithDistance(fn DistanceFunc) DistanceOption {
-	return DistanceOption{fn}
+	return distanceOption{fn}
 }


### PR DESCRIPTION
## Summary

Refactors option constructors to reduce public API surface and decouple internals from exported concrete types.

- Converts exported concrete option types (`SizeOption`, `SigmaOption`, etc.) into exported interfaces.
- Introduces unexported concrete implementations (`sizeOption`, `sigmaOption`, etc.).
- Updates all `With*` constructors to return interfaces while preserving existing usage patterns.
- Keeps option application behavior unchanged.

This addresses the maintainability concern that exported concrete option structs lock internals and make future refactors harder.

## Related Issue

N/A

## Type of Change

- [x] `fix` (bug fix)
- [ ] `feat` (new feature)
- [ ] `docs` (documentation only)
- [ ] `test` (tests only)
- [x] `chore` (maintenance/refactor/tooling)
- [ ] Breaking change

## Validation

```bash
go test ./...
```

Result: all packages passed.

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [ ] I added or updated tests for behavior changes.
- [ ] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

None.
