### PR TITLE
feat: Color Layout Descriptor Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Use the algorithm's `Compare` method for its recommended metric, or call top-lev
 
 ## Perceptual Hash Algorithms
 
-The library supports 13 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
+The library supports 14 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
 
 Every constructor accepts functional options. Call with no arguments for defaults, or pass `With*` options to customize:
 
@@ -198,6 +198,22 @@ dist, err := cm.Compare(h1, h2) // L2 distance
 | `WithInterpolation(i)` | `Bicubic` |
 | `WithKernelSize(k)` | 3 |
 | `WithSigma(s)` | 0 |
+
+#### MPEG-7 Color Layout Descriptor (CLD)
+
+Builds a compact 12-element uint8 descriptor (6 Y coefficients + 3 Cb + 3 Cr) from an 8x8 color layout in YCbCr space. The image is resized, partitioned into an 8x8 grid, transformed with a 2D DCT per channel, and low-frequency coefficients are sampled in zig-zag order with CLD-style quantization. Compares using L1 (Manhattan) distance.
+
+```go
+cld, err := imghash.NewCLD()
+h1, err := cld.Calculate(img1)
+h2, err := cld.Calculate(img2)
+dist, err := cld.Compare(h1, h2) // L1 distance
+```
+
+| Option | Default |
+|--------|---------|
+| `WithSize(w, h)` | 64, 64 |
+| `WithInterpolation(i)` | `Bilinear` |
 
 #### Marr-Hildreth Hash
 

--- a/cld.go
+++ b/cld.go
@@ -1,0 +1,180 @@
+package imghash
+
+import (
+	"image"
+	"image/color"
+	"math"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
+)
+
+const (
+	cldGridSize     = 8
+	cldYCoeffs      = 6
+	cldCCoeffs      = 3
+	cldHashLen      = cldYCoeffs + 2*cldCCoeffs
+	cldDCQuantRange = 63
+	cldACQuantRange = 31
+	cldACCenter     = 16
+	cldACScale      = 16.0
+)
+
+// Zig-zag order for an 8x8 block, represented as row-major indices.
+var cldZigZag = [64]uint8{
+	0, 1, 8, 16, 9, 2, 3, 10,
+	17, 24, 32, 25, 18, 11, 4, 5,
+	12, 19, 26, 33, 40, 48, 41, 34,
+	27, 20, 13, 6, 7, 14, 21, 28,
+	35, 42, 49, 56, 57, 50, 43, 36,
+	29, 22, 15, 23, 30, 37, 44, 51,
+	58, 59, 52, 45, 38, 31, 39, 46,
+	53, 60, 61, 54, 47, 55, 62, 63,
+}
+
+// CLD is an MPEG-7 Color Layout Descriptor style perceptual hash.
+// The image is converted to YCbCr, summarised into an 8x8 layout, transformed
+// with a 2-D DCT per channel, then low-frequency zig-zag coefficients are
+// quantised into a compact 12-element descriptor.
+type CLD struct {
+	baseConfig
+	distFunc DistanceFunc
+}
+
+// NewCLD creates a new CLD hash with the given options.
+// Without options, sensible defaults are used.
+func NewCLD(opts ...CLDOption) (CLD, error) {
+	c := CLD{
+		baseConfig: baseConfig{width: 64, height: 64, interp: Bilinear},
+	}
+	for _, o := range opts {
+		o.applyCLD(&c)
+	}
+	if err := c.validate(); err != nil {
+		return CLD{}, err
+	}
+	return c, nil
+}
+
+// Calculate returns an MPEG-7 CLD style perceptual hash.
+func (c CLD) Calculate(img image.Image) (hashtype.Hash, error) {
+	r := imgproc.Resize(c.width, c.height, img, c.interp.resizeType())
+	y, cb, cr := c.layoutYCbCr(r)
+
+	yDCT := imgproc.DCT(y)
+	cbDCT := imgproc.DCT(cb)
+	crDCT := imgproc.DCT(cr)
+
+	hash := make(hashtype.UInt8, cldHashLen)
+	hash[0] = quantizeCLDDC(yDCT[0][0])
+	for i := 1; i < cldYCoeffs; i++ {
+		hash[i] = quantizeCLDAC(zigZagCoeff(yDCT, i))
+	}
+
+	offset := cldYCoeffs
+	hash[offset] = quantizeCLDDC(cbDCT[0][0])
+	for i := 1; i < cldCCoeffs; i++ {
+		hash[offset+i] = quantizeCLDAC(zigZagCoeff(cbDCT, i))
+	}
+
+	offset += cldCCoeffs
+	hash[offset] = quantizeCLDDC(crDCT[0][0])
+	for i := 1; i < cldCCoeffs; i++ {
+		hash[offset+i] = quantizeCLDAC(zigZagCoeff(crDCT, i))
+	}
+
+	return hash, nil
+}
+
+func (c CLD) layoutYCbCr(img image.Image) ([][]float32, [][]float32, [][]float32) {
+	bounds := img.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+
+	y := make([][]float32, cldGridSize)
+	cb := make([][]float32, cldGridSize)
+	cr := make([][]float32, cldGridSize)
+	for i := 0; i < cldGridSize; i++ {
+		y[i] = make([]float32, cldGridSize)
+		cb[i] = make([]float32, cldGridSize)
+		cr[i] = make([]float32, cldGridSize)
+	}
+
+	for gy := 0; gy < cldGridSize; gy++ {
+		y0 := gy * h / cldGridSize
+		y1 := (gy + 1) * h / cldGridSize
+		if y1 <= y0 {
+			if y0 >= h {
+				y0 = h - 1
+			}
+			y1 = y0 + 1
+		}
+		for gx := 0; gx < cldGridSize; gx++ {
+			x0 := gx * w / cldGridSize
+			x1 := (gx + 1) * w / cldGridSize
+			if x1 <= x0 {
+				if x0 >= w {
+					x0 = w - 1
+				}
+				x1 = x0 + 1
+			}
+
+			var sy, scb, scr float64
+			var n float64
+			for yy := y0; yy < y1; yy++ {
+				for xx := x0; xx < x1; xx++ {
+					r, g, b, _ := img.At(bounds.Min.X+xx, bounds.Min.Y+yy).RGBA()
+					yyc, cbc, crc := color.RGBToYCbCr(uint8(r>>8), uint8(g>>8), uint8(b>>8))
+					sy += float64(yyc)
+					scb += float64(cbc)
+					scr += float64(crc)
+					n++
+				}
+			}
+			y[gy][gx] = float32(sy / n)
+			cb[gy][gx] = float32(scb / n)
+			cr[gy][gx] = float32(scr / n)
+		}
+	}
+
+	return y, cb, cr
+}
+
+func zigZagCoeff(dct [][]float32, idx int) float64 {
+	pos := cldZigZag[idx]
+	return float64(dct[pos/cldGridSize][pos%cldGridSize])
+}
+
+func quantizeCLDDC(dc float32) uint8 {
+	// For orthonormal 8x8 DCT the DC term equals mean*8; map mean [0,255] to 6 bits.
+	mean := float64(dc) / cldGridSize
+	q := int(math.Round(mean * cldDCQuantRange / 255.0))
+	return uint8(clampInt(q, 0, cldDCQuantRange))
+}
+
+func quantizeCLDAC(ac float64) uint8 {
+	// Signed 5-bit quantisation with midpoint at 16.
+	q := int(math.Round(ac/cldACScale)) + cldACCenter
+	return uint8(clampInt(q, 0, cldACQuantRange))
+}
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// Compare computes the L1 (Manhattan) distance between two CLD hashes.
+func (c CLD) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateUInt8CompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
+	if c.distFunc != nil {
+		return c.distFunc(h1, h2)
+	}
+	return similarity.L1(h1, h2)
+}

--- a/cld_test.go
+++ b/cld_test.go
@@ -1,0 +1,135 @@
+package imghash_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
+)
+
+var cldCalculateTests = []struct {
+	filename   string
+	hash       hashtype.UInt8
+	width      uint
+	height     uint
+	resizeType imghash.Interpolation
+}{
+	{"assets/lena.jpg", hashtype.UInt8{31, 11, 19, 16, 20, 15, 29, 17, 14, 42, 18, 17}, 64, 64, imghash.Bilinear},
+	{"assets/baboon.jpg", hashtype.UInt8{32, 16, 13, 15, 13, 14, 29, 14, 17, 33, 18, 12}, 64, 64, imghash.Bilinear},
+	{"assets/cat.jpg", hashtype.UInt8{36, 26, 31, 27, 19, 16, 28, 15, 17, 35, 16, 13}, 64, 64, imghash.Bilinear},
+	{"assets/monarch.jpg", hashtype.UInt8{26, 18, 15, 12, 19, 17, 27, 18, 16, 38, 19, 15}, 64, 64, imghash.Bilinear},
+	{"assets/peppers.jpg", hashtype.UInt8{30, 16, 20, 16, 11, 16, 24, 14, 15, 37, 17, 17}, 64, 64, imghash.Bilinear},
+	{"assets/tulips.jpg", hashtype.UInt8{26, 20, 17, 11, 15, 8, 30, 16, 16, 33, 17, 16}, 64, 64, imghash.Bilinear},
+}
+
+func TestCLD_Calculate(t *testing.T) {
+	for _, tt := range cldCalculateTests {
+		t.Run(tt.filename, func(t *testing.T) {
+			hash, err := imghash.NewCLD(imghash.WithSize(tt.width, tt.height), imghash.WithInterpolation(tt.resizeType))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img, err := imghash.OpenImage(tt.filename)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.filename, err)
+			}
+			result, err := hash.Calculate(img)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			res := result.(hashtype.UInt8)
+			if !res.Equal(tt.hash) {
+				t.Errorf("got %v, want %v", res, tt.hash)
+			}
+		})
+	}
+}
+
+func ExampleCLD_Calculate() {
+	img, err := imghash.OpenImage("assets/cat.jpg")
+	if err != nil {
+		panic(err)
+	}
+	cld, err := imghash.NewCLD()
+	if err != nil {
+		panic(err)
+	}
+	hash, err := cld.Calculate(img)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hash)
+	// Output: [36 26 31 27 19 16 28 15 17 35 16 13]
+}
+
+var cldDistanceTests = []struct {
+	firstImage  string
+	secondImage string
+	distance    similarity.Distance
+	width       uint
+	height      uint
+	resizeType  imghash.Interpolation
+}{
+	{"assets/lena.jpg", "assets/cat.jpg", 64, 64, 64, imghash.Bilinear},
+	{"assets/lena.jpg", "assets/monarch.jpg", 35, 64, 64, imghash.Bilinear},
+	{"assets/baboon.jpg", "assets/cat.jpg", 59, 64, 64, imghash.Bilinear},
+	{"assets/peppers.jpg", "assets/baboon.jpg", 31, 64, 64, imghash.Bilinear},
+	{"assets/tulips.jpg", "assets/monarch.jpg", 31, 64, 64, imghash.Bilinear},
+}
+
+func TestCLD_Distance(t *testing.T) {
+	for _, tt := range cldDistanceTests {
+		t.Run(fmt.Sprintf("%v %v", tt.firstImage, tt.secondImage), func(t *testing.T) {
+			hash, err := imghash.NewCLD(imghash.WithSize(tt.width, tt.height), imghash.WithInterpolation(tt.resizeType))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img1, err := imghash.OpenImage(tt.firstImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.firstImage, err)
+			}
+			img2, err := imghash.OpenImage(tt.secondImage)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.secondImage, err)
+			}
+			h1, err := hash.Calculate(img1)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.firstImage, err)
+			}
+			h2, err := hash.Calculate(img2)
+			if err != nil {
+				t.Fatalf("failed to calculate hash for %s: %v", tt.secondImage, err)
+			}
+			dist, err := hash.Compare(h1, h2)
+			if err != nil {
+				t.Fatalf("failed to compute distance: %v", err)
+			}
+			if !dist.Equal(tt.distance) {
+				t.Errorf("got %v, want %v", dist, tt.distance)
+			}
+		})
+	}
+}
+
+func TestNewCLD_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []imghash.CLDOption
+		err  error
+	}{
+		{"zero width", []imghash.CLDOption{imghash.WithSize(0, 64)}, imghash.ErrInvalidSize},
+		{"zero height", []imghash.CLDOption{imghash.WithSize(64, 0)}, imghash.ErrInvalidSize},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := imghash.NewCLD(tt.opts...)
+			if !errors.Is(err, tt.err) {
+				t.Errorf("got %v, want %v", err, tt.err)
+			}
+		})
+	}
+}

--- a/distance_options_test.go
+++ b/distance_options_test.go
@@ -190,6 +190,19 @@ var compareCases = []compareCase{
 		invalidLen1:  hashtype.Float64{1.0, 2.0},
 		invalidLen2:  hashtype.Float64{1.0, 2.0, 3.0},
 	},
+	{
+		name:         "CLD",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewCLD() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewCLD(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.UInt8{1, 2, 3},
+		valid2:       hashtype.UInt8{3, 2, 1},
+		invalidType1: hashtype.Binary{0x00, 0xFF},
+		invalidType2: hashtype.Binary{0xFF, 0x00},
+		invalidLen1:  hashtype.UInt8{1, 2},
+		invalidLen2:  hashtype.UInt8{1, 2, 3},
+	},
 }
 
 func TestWithDistance_overrideAcrossHashers(t *testing.T) {

--- a/imghash.go
+++ b/imghash.go
@@ -17,7 +17,7 @@ type DistanceFunc func(hashtype.Hash, hashtype.Hash) (similarity.Distance, error
 // Hasher computes a perceptual hash from an image.
 // It is implemented by all hash algorithms in this package:
 // Average, Difference, PHash, Median, BlockMean, MarrHildreth,
-// RadialVariance, ColorMoment, WHash, LBP, HOGHash, PDQ, and RASH.
+// RadialVariance, ColorMoment, CLD, WHash, LBP, HOGHash, PDQ, and RASH.
 type Hasher interface {
 	Calculate(image.Image) (hashtype.Hash, error)
 }
@@ -46,6 +46,7 @@ var (
 	_ HasherComparer = MarrHildreth{}
 	_ HasherComparer = RadialVariance{}
 	_ HasherComparer = ColorMoment{}
+	_ HasherComparer = CLD{}
 	_ HasherComparer = WHash{}
 	_ HasherComparer = LBP{}
 	_ HasherComparer = HOGHash{}

--- a/interpolation_validation_test.go
+++ b/interpolation_validation_test.go
@@ -63,6 +63,13 @@ func TestWithInterpolation_invalidValue(t *testing.T) {
 			},
 		},
 		{
+			name: "CLD",
+			new: func() error {
+				_, err := imghash.NewCLD(imghash.WithInterpolation(invalid))
+				return err
+			},
+		},
+		{
 			name: "WHash",
 			new: func() error {
 				_, err := imghash.NewWHash(imghash.WithInterpolation(invalid))

--- a/options.go
+++ b/options.go
@@ -42,6 +42,9 @@ type RadialVarianceOption interface{ applyRadialVariance(*RadialVariance) }
 // ColorMomentOption configures the ColorMoment hash algorithm.
 type ColorMomentOption interface{ applyColorMoment(*ColorMoment) }
 
+// CLDOption configures the CLD hash algorithm.
+type CLDOption interface{ applyCLD(*CLD) }
+
 // WHashOption configures the WHash algorithm.
 type WHashOption interface{ applyWHash(*WHash) }
 
@@ -70,6 +73,7 @@ type DistanceOption interface {
 	MarrHildrethOption
 	RadialVarianceOption
 	ColorMomentOption
+	CLDOption
 	WHashOption
 	LBPOption
 	HOGHashOption
@@ -87,6 +91,7 @@ func (o distanceOption) applyBlockMean(b *BlockMean)           { b.distFunc = o.
 func (o distanceOption) applyMarrHildreth(m *MarrHildreth)     { m.distFunc = o.fn }
 func (o distanceOption) applyRadialVariance(r *RadialVariance) { r.distFunc = o.fn }
 func (o distanceOption) applyColorMoment(c *ColorMoment)       { c.distFunc = o.fn }
+func (o distanceOption) applyCLD(c *CLD)                       { c.distFunc = o.fn }
 func (o distanceOption) applyWHash(w *WHash)                   { w.distFunc = o.fn }
 func (o distanceOption) applyLBP(l *LBP)                       { l.distFunc = o.fn }
 func (o distanceOption) applyHOGHash(h *HOGHash)               { h.distFunc = o.fn }
@@ -104,6 +109,7 @@ type SizeOption interface {
 	BlockMeanOption
 	MarrHildrethOption
 	ColorMomentOption
+	CLDOption
 	WHashOption
 	LBPOption
 	HOGHashOption
@@ -120,6 +126,7 @@ func (o sizeOption) applyPHash(p *PHash)               { o.applyBase(&p.baseConf
 func (o sizeOption) applyBlockMean(b *BlockMean)       { o.applyBase(&b.baseConfig) }
 func (o sizeOption) applyMarrHildreth(m *MarrHildreth) { o.applyBase(&m.baseConfig) }
 func (o sizeOption) applyColorMoment(c *ColorMoment)   { o.applyBase(&c.baseConfig) }
+func (o sizeOption) applyCLD(c *CLD)                   { o.applyBase(&c.baseConfig) }
 func (o sizeOption) applyWHash(w *WHash)               { o.applyBase(&w.baseConfig) }
 func (o sizeOption) applyLBP(l *LBP)                   { o.applyBase(&l.baseConfig) }
 func (o sizeOption) applyHOGHash(h *HOGHash)           { o.applyBase(&h.baseConfig) }
@@ -134,6 +141,7 @@ type InterpolationOption interface {
 	BlockMeanOption
 	MarrHildrethOption
 	ColorMomentOption
+	CLDOption
 	WHashOption
 	LBPOption
 	HOGHashOption
@@ -151,6 +159,7 @@ func (o interpolationOption) applyPHash(p *PHash)               { o.applyBase(&p
 func (o interpolationOption) applyBlockMean(b *BlockMean)       { o.applyBase(&b.baseConfig) }
 func (o interpolationOption) applyMarrHildreth(m *MarrHildreth) { o.applyBase(&m.baseConfig) }
 func (o interpolationOption) applyColorMoment(c *ColorMoment)   { o.applyBase(&c.baseConfig) }
+func (o interpolationOption) applyCLD(c *CLD)                   { o.applyBase(&c.baseConfig) }
 func (o interpolationOption) applyWHash(w *WHash)               { o.applyBase(&w.baseConfig) }
 func (o interpolationOption) applyLBP(l *LBP)                   { o.applyBase(&l.baseConfig) }
 func (o interpolationOption) applyHOGHash(h *HOGHash)           { o.applyBase(&h.baseConfig) }
@@ -285,13 +294,13 @@ func (o weightsOption) applyPHash(p *PHash) { p.weights = append([]float64(nil),
 // --- public constructors ---
 
 // WithSize sets the resize dimensions used during hash computation.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, HOGHash, and RASH.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, CLD, WHash, LBP, HOGHash, and RASH.
 func WithSize(width, height uint) SizeOption {
 	return sizeOption{width, height}
 }
 
 // WithInterpolation sets the resize interpolation method.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, WHash, LBP, HOGHash, PDQ, and RASH.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, CLD, WHash, LBP, HOGHash, PDQ, and RASH.
 func WithInterpolation(interp Interpolation) InterpolationOption {
 	return interpolationOption{interp}
 }

--- a/options_typecheck_test.go
+++ b/options_typecheck_test.go
@@ -45,6 +45,10 @@ var _ ColorMomentOption = WithKernelSize(0)
 var _ ColorMomentOption = WithSigma(0)
 var _ ColorMomentOption = WithDistance(nil)
 
+var _ CLDOption = WithSize(0, 0)
+var _ CLDOption = WithInterpolation(Bilinear)
+var _ CLDOption = WithDistance(nil)
+
 var _ WHashOption = WithSize(0, 0)
 var _ WHashOption = WithInterpolation(Bilinear)
 var _ WHashOption = WithLevel(0)


### PR DESCRIPTION
## Summary

Implements an MPEG-7 Color Layout Descriptor (CLD) hash and integrates it into the library API, options, tests, and docs.

Key changes:
- Adds new `CLD` hasher with `NewCLD(opts ...CLDOption)`.
- Implements CLD pipeline in `cld.go`:
  - resize + interpolation
  - YCbCr 8x8 layout extraction
  - per-channel 2D DCT
  - zig-zag low-frequency sampling
  - quantized 12-element `hashtype.UInt8` descriptor (6 Y + 3 Cb + 3 Cr)
- Uses `L1` as the default CLD distance metric in `Compare`.
- Wires CLD into shared option plumbing (`WithSize`, `WithInterpolation`, `WithDistance`).
- Registers CLD in interface compile-time assertions.
- Adds dedicated tests in `cld_test.go`:
  - deterministic calculate vectors on sample assets
  - distance expectations
  - example
  - constructor validation
- Extends cross-cutting test suites to include CLD (`distance_options_test.go`, `interpolation_validation_test.go`, `options_typecheck_test.go`).
- Updates README:
  - algorithm count `13 -> 14`
  - adds CLD section with defaults and usage.

## Related Issue

N/A

## Type of Change

- [x] `feat` (new feature)
- [ ] `fix` (bug fix)
- [x] `docs` (documentation only)
- [x] `test` (tests only)
- [ ] `chore` (maintenance/refactor/tooling)
- [ ] Breaking change

## Validation

Ran locally:

```bash
GOCACHE=/tmp/gocache go test ./...
```

Result:
- all packages passed.

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

None.
