### PR TITLE
feat: GIST Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ func main() {
 | RASH | `Binary` | Hamming |
 | ColorMoment | `Float64` | L2 (Euclidean) |
 | Zernike | `Float64` | L2 (Euclidean) |
+| GIST | `Float64` | Cosine |
 | CLD | `UInt8` | L2 (Euclidean) |
 | EHD | `UInt8` | L1 (Manhattan) |
 | LBP | `UInt8` | Chi-Square |

--- a/distance_options_test.go
+++ b/distance_options_test.go
@@ -204,6 +204,19 @@ var compareCases = []compareCase{
 		invalidLen2:  hashtype.Float64{1.0, 2.0, 3.0},
 	},
 	{
+		name:         "GIST",
+		buildDefault: func() (imghash.Comparer, error) { return imghash.NewGIST() },
+		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {
+			return imghash.NewGIST(imghash.WithDistance(fn))
+		},
+		valid1:       hashtype.Float64{1.0, 2.0},
+		valid2:       hashtype.Float64{3.0, 4.0},
+		invalidType1: hashtype.UInt8{1, 2},
+		invalidType2: hashtype.UInt8{3, 4},
+		invalidLen1:  hashtype.Float64{1.0, 2.0},
+		invalidLen2:  hashtype.Float64{1.0, 2.0, 3.0},
+	},
+	{
 		name:         "CLD",
 		buildDefault: func() (imghash.Comparer, error) { return imghash.NewCLD() },
 		buildWithDistance: func(fn imghash.DistanceFunc) (imghash.Comparer, error) {

--- a/gist.go
+++ b/gist.go
@@ -1,0 +1,257 @@
+package imghash
+
+import (
+	"image"
+	"math"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
+)
+
+var gistOrientationsPerScale = []int{8, 8, 4}
+
+// GIST is a holistic scene descriptor based on a bank of oriented Gabor
+// filters pooled over a coarse spatial grid.
+//
+// Based on: A. Oliva and A. Torralba, "Modeling the Shape of the Scene:
+// A Holistic Representation of the Spatial Envelope" (2001).
+type GIST struct {
+	baseConfig
+	gridX, gridY uint
+	distFunc     DistanceFunc
+}
+
+// NewGIST creates a new GIST hash with the given options.
+// Without options, sensible defaults are used.
+func NewGIST(opts ...GISTOption) (GIST, error) {
+	g := GIST{
+		baseConfig: baseConfig{width: 64, height: 64, interp: Bilinear},
+		gridX:      4,
+		gridY:      4,
+	}
+	for _, o := range opts {
+		o.applyGIST(&g)
+	}
+	if err := g.validate(); err != nil {
+		return GIST{}, err
+	}
+	if g.gridX == 0 || g.gridY == 0 {
+		return GIST{}, ErrInvalidGridSize
+	}
+	return g, nil
+}
+
+// Calculate returns a perceptual image hash.
+func (g GIST) Calculate(img image.Image) (hashtype.Hash, error) {
+	r := imgproc.Resize(g.width, g.height, img, g.interp.resizeType())
+	gray, err := imgproc.Grayscale(r)
+	if err != nil {
+		return nil, err
+	}
+	mat := g.normalizeGray(gray)
+	desc := g.computeDescriptor(mat)
+	return hashtype.Float64(desc), nil
+}
+
+func (g GIST) normalizeGray(img *image.Gray) [][]float64 {
+	bounds := img.Bounds()
+	w, h := bounds.Dx(), bounds.Dy()
+	ox, oy := bounds.Min.X, bounds.Min.Y
+	mat := make([][]float64, h)
+	var mean float64
+	for y := 0; y < h; y++ {
+		mat[y] = make([]float64, w)
+		for x := 0; x < w; x++ {
+			v := float64(img.GrayAt(x+ox, y+oy).Y) / 255
+			mat[y][x] = v
+			mean += v
+		}
+	}
+
+	n := float64(w * h)
+	if n == 0 {
+		return mat
+	}
+	mean /= n
+
+	var variance float64
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			d := mat[y][x] - mean
+			variance += d * d
+		}
+	}
+	std := math.Sqrt(variance / n)
+	if std < 1e-12 {
+		std = 1
+	}
+
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			mat[y][x] = (mat[y][x] - mean) / std
+		}
+	}
+	return mat
+}
+
+func (g GIST) computeDescriptor(img [][]float64) []float64 {
+	h := len(img)
+	if h == 0 {
+		return []float64{}
+	}
+	w := len(img[0])
+	if w == 0 {
+		return []float64{}
+	}
+
+	gridX, gridY := int(g.gridX), int(g.gridY)
+	cellCounts := make([]int, gridX*gridY)
+	for y := 0; y < h; y++ {
+		by := y * gridY / h
+		for x := 0; x < w; x++ {
+			bx := x * gridX / w
+			cellCounts[by*gridX+bx]++
+		}
+	}
+
+	totalOrientations := 0
+	for _, o := range gistOrientationsPerScale {
+		totalOrientations += o
+	}
+	descriptor := make([]float64, 0, gridX*gridY*totalOrientations)
+
+	wavelengths := []float64{4, 8, 12}
+	for s, nOrient := range gistOrientationsPerScale {
+		wavelength := wavelengths[s]
+		for o := 0; o < nOrient; o++ {
+			theta := float64(o) * math.Pi / float64(nOrient)
+			kReal, kImag := gistGaborKernel(theta, wavelength)
+			cellSums := gistFilterPool(img, kReal, kImag, gridX, gridY)
+			for i := range cellSums {
+				if cellCounts[i] > 0 {
+					descriptor = append(descriptor, cellSums[i]/float64(cellCounts[i]))
+				} else {
+					descriptor = append(descriptor, 0)
+				}
+			}
+		}
+	}
+
+	var norm float64
+	for _, v := range descriptor {
+		norm += v * v
+	}
+	norm = math.Sqrt(norm)
+	if norm > 0 {
+		for i := range descriptor {
+			descriptor[i] /= norm
+		}
+	}
+
+	return descriptor
+}
+
+func gistGaborKernel(theta, wavelength float64) ([][]float64, [][]float64) {
+	sigma := 0.56 * wavelength
+	gamma := 0.5
+	radius := int(math.Ceil(2 * sigma))
+	if radius < 3 {
+		radius = 3
+	}
+	if radius > 9 {
+		radius = 9
+	}
+	size := 2*radius + 1
+
+	kernelReal := make([][]float64, size)
+	kernelImag := make([][]float64, size)
+	cosTheta := math.Cos(theta)
+	sinTheta := math.Sin(theta)
+
+	var norm float64
+	for y := -radius; y <= radius; y++ {
+		yy := y + radius
+		kernelReal[yy] = make([]float64, size)
+		kernelImag[yy] = make([]float64, size)
+		for x := -radius; x <= radius; x++ {
+			xx := x + radius
+			xTheta := float64(x)*cosTheta + float64(y)*sinTheta
+			yTheta := -float64(x)*sinTheta + float64(y)*cosTheta
+			gauss := math.Exp(-(xTheta*xTheta + gamma*gamma*yTheta*yTheta) / (2 * sigma * sigma))
+			phase := 2 * math.Pi * xTheta / wavelength
+			r := gauss * math.Cos(phase)
+			i := gauss * math.Sin(phase)
+			kernelReal[yy][xx] = r
+			kernelImag[yy][xx] = i
+			norm += r*r + i*i
+		}
+	}
+
+	norm = math.Sqrt(norm)
+	if norm > 0 {
+		for y := range kernelReal {
+			for x := range kernelReal[y] {
+				kernelReal[y][x] /= norm
+				kernelImag[y][x] /= norm
+			}
+		}
+	}
+
+	return kernelReal, kernelImag
+}
+
+func gistFilterPool(img, kReal, kImag [][]float64, gridX, gridY int) []float64 {
+	h := len(img)
+	w := len(img[0])
+	kh := len(kReal)
+	kw := len(kReal[0])
+	ry := kh / 2
+	rx := kw / 2
+
+	cellSums := make([]float64, gridX*gridY)
+	for y := 0; y < h; y++ {
+		by := y * gridY / h
+		for x := 0; x < w; x++ {
+			var sumR, sumI float64
+			for ky := 0; ky < kh; ky++ {
+				iy := gistReflect101(y+ky-ry, h)
+				for kx := 0; kx < kw; kx++ {
+					ix := gistReflect101(x+kx-rx, w)
+					p := img[iy][ix]
+					sumR += p * kReal[ky][kx]
+					sumI += p * kImag[ky][kx]
+				}
+			}
+			bx := x * gridX / w
+			cellSums[by*gridX+bx] += math.Hypot(sumR, sumI)
+		}
+	}
+
+	return cellSums
+}
+
+func gistReflect101(idx, size int) int {
+	if size <= 1 {
+		return 0
+	}
+	for idx < 0 || idx >= size {
+		if idx < 0 {
+			idx = -idx
+			continue
+		}
+		idx = 2*size - idx - 2
+	}
+	return idx
+}
+
+// Compare computes the cosine distance between two GIST hashes.
+func (g GIST) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateFloat64CompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
+	if g.distFunc != nil {
+		return g.distFunc(h1, h2)
+	}
+	return similarity.Cosine(h1, h2)
+}

--- a/gist_test.go
+++ b/gist_test.go
@@ -1,0 +1,148 @@
+package imghash_test
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
+)
+
+func TestGIST_Calculate(t *testing.T) {
+	g, err := imghash.NewGIST()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	img, err := imghash.OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	h, err := g.Calculate(img)
+	if err != nil {
+		t.Fatalf("failed to calculate hash: %v", err)
+	}
+	got := h.(hashtype.Float64)
+	if got.Len() != 320 {
+		t.Fatalf("expected hash length 320, got %d", got.Len())
+	}
+
+	var energy float64
+	for _, v := range got {
+		energy += v * v
+	}
+	if energy <= 0 {
+		t.Fatal("expected non-zero descriptor energy")
+	}
+}
+
+func TestGIST_DistanceUsesCosineByDefault(t *testing.T) {
+	g, err := imghash.NewGIST()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	img1, err := imghash.OpenImage("assets/lena.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	img2, err := imghash.OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	h1, err := g.Calculate(img1)
+	if err != nil {
+		t.Fatalf("failed to calculate hash: %v", err)
+	}
+	h2, err := g.Calculate(img2)
+	if err != nil {
+		t.Fatalf("failed to calculate hash: %v", err)
+	}
+
+	got, err := g.Compare(h1, h2)
+	if err != nil {
+		t.Fatalf("failed to compare: %v", err)
+	}
+	want, err := similarity.Cosine(h1, h2)
+	if err != nil {
+		t.Fatalf("failed to compute cosine distance: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestGIST_DistanceCosineBehavior(t *testing.T) {
+	g, err := imghash.NewGIST()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := g.Compare(hashtype.Float64{1, 0}, hashtype.Float64{0, 1})
+	if err != nil {
+		t.Fatalf("failed to compare: %v", err)
+	}
+	if math.Abs(float64(got)-1) > 1e-12 {
+		t.Fatalf("got %v, want 1", got)
+	}
+}
+
+func TestNewGIST_CustomGridSize(t *testing.T) {
+	g, err := imghash.NewGIST(imghash.WithGridSize(2, 2))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	img, err := imghash.OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open image: %v", err)
+	}
+	h, err := g.Calculate(img)
+	if err != nil {
+		t.Fatalf("failed to calculate hash: %v", err)
+	}
+	if h.Len() != 80 {
+		t.Fatalf("expected hash length 80, got %d", h.Len())
+	}
+}
+
+func TestNewGIST_Errors(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []imghash.GISTOption
+		err  error
+	}{
+		{"zero width", []imghash.GISTOption{imghash.WithSize(0, 64)}, imghash.ErrInvalidSize},
+		{"zero height", []imghash.GISTOption{imghash.WithSize(64, 0)}, imghash.ErrInvalidSize},
+		{"invalid interpolation", []imghash.GISTOption{imghash.WithInterpolation(imghash.Interpolation(999))}, imghash.ErrInvalidInterpolation},
+		{"zero grid x", []imghash.GISTOption{imghash.WithGridSize(0, 4)}, imghash.ErrInvalidGridSize},
+		{"zero grid y", []imghash.GISTOption{imghash.WithGridSize(4, 0)}, imghash.ErrInvalidGridSize},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := imghash.NewGIST(tt.opts...)
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("got %v, want %v", err, tt.err)
+			}
+		})
+	}
+}
+
+func ExampleGIST_Calculate() {
+	img, err := imghash.OpenImage("assets/cat.jpg")
+	if err != nil {
+		panic(err)
+	}
+	g, err := imghash.NewGIST()
+	if err != nil {
+		panic(err)
+	}
+	hash, err := g.Calculate(img)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(hash.Len())
+	// Output: 320
+}

--- a/imghash.go
+++ b/imghash.go
@@ -17,7 +17,7 @@ type DistanceFunc func(hashtype.Hash, hashtype.Hash) (similarity.Distance, error
 // Hasher computes a perceptual hash from an image.
 // It is implemented by all hash algorithms in this package:
 // Average, Difference, PHash, Median, BlockMean, MarrHildreth,
-// RadialVariance, ColorMoment, CLD, EHD, WHash, LBP, HOGHash, PDQ, RASH, and Zernike.
+// RadialVariance, ColorMoment, CLD, EHD, WHash, LBP, HOGHash, PDQ, RASH, Zernike, and GIST.
 type Hasher interface {
 	Calculate(image.Image) (hashtype.Hash, error)
 }
@@ -54,6 +54,7 @@ var (
 	_ HasherComparer = PDQ{}
 	_ HasherComparer = RASH{}
 	_ HasherComparer = Zernike{}
+	_ HasherComparer = GIST{}
 )
 
 // Re-export core types so most consumers only need to import "imghash".

--- a/options.go
+++ b/options.go
@@ -66,6 +66,9 @@ type RASHOption interface{ applyRASH(*RASH) }
 // ZernikeOption configures the Zernike hash algorithm.
 type ZernikeOption interface{ applyZernike(*Zernike) }
 
+// GISTOption configures the GIST hash algorithm.
+type GISTOption interface{ applyGIST(*GIST) }
+
 // Option interfaces returned by With* constructors.
 // Concrete implementations are intentionally unexported.
 
@@ -87,6 +90,7 @@ type DistanceOption interface {
 	PDQOption
 	RASHOption
 	ZernikeOption
+	GISTOption
 }
 
 type distanceOption struct{ fn DistanceFunc }
@@ -107,6 +111,7 @@ func (o distanceOption) applyHOGHash(h *HOGHash)               { h.distFunc = o.
 func (o distanceOption) applyPDQ(p *PDQ)                       { p.distFunc = o.fn }
 func (o distanceOption) applyRASH(r *RASH)                     { r.distFunc = o.fn }
 func (o distanceOption) applyZernike(z *Zernike)               { z.distFunc = o.fn }
+func (o distanceOption) applyGIST(g *GIST)                     { g.distFunc = o.fn }
 
 // --- concrete option implementations ---
 
@@ -126,6 +131,7 @@ type SizeOption interface {
 	HOGHashOption
 	RASHOption
 	ZernikeOption
+	GISTOption
 }
 
 type sizeOption struct{ width, height uint }
@@ -145,6 +151,7 @@ func (o sizeOption) applyLBP(l *LBP)                   { o.applyBase(&l.baseConf
 func (o sizeOption) applyHOGHash(h *HOGHash)           { o.applyBase(&h.baseConfig) }
 func (o sizeOption) applyRASH(r *RASH)                 { o.applyBase(&r.baseConfig) }
 func (o sizeOption) applyZernike(z *Zernike)           { o.applyBase(&z.baseConfig) }
+func (o sizeOption) applyGIST(g *GIST)                 { o.applyBase(&g.baseConfig) }
 
 // InterpolationOption sets the resize interpolation method.
 type InterpolationOption interface {
@@ -163,6 +170,7 @@ type InterpolationOption interface {
 	PDQOption
 	RASHOption
 	ZernikeOption
+	GISTOption
 }
 
 type interpolationOption struct{ interp Interpolation }
@@ -183,6 +191,7 @@ func (o interpolationOption) applyHOGHash(h *HOGHash)           { o.applyBase(&h
 func (o interpolationOption) applyPDQ(p *PDQ)                   { p.interp = o.interp }
 func (o interpolationOption) applyRASH(r *RASH)                 { o.applyBase(&r.baseConfig) }
 func (o interpolationOption) applyZernike(z *Zernike)           { o.applyBase(&z.baseConfig) }
+func (o interpolationOption) applyGIST(g *GIST)                 { o.applyBase(&g.baseConfig) }
 
 // KernelSizeOption sets the Gaussian kernel size.
 type KernelSizeOption interface {
@@ -267,11 +276,15 @@ func (o levelOption) applyWHash(w *WHash) { w.level = o.level }
 // GridSizeOption sets the grid cell count for spatial histograms.
 type GridSizeOption interface {
 	LBPOption
+	GISTOption
 }
 
 type gridSizeOption struct{ x, y uint }
 
 func (o gridSizeOption) applyLBP(l *LBP) { l.gridX, l.gridY = o.x, o.y }
+func (o gridSizeOption) applyGIST(g *GIST) {
+	g.gridX, g.gridY = o.x, o.y
+}
 
 // CellSizeOption sets the cell size in pixels for HOG computation.
 type CellSizeOption interface {
@@ -321,13 +334,13 @@ func (o weightsOption) applyPHash(p *PHash) { p.weights = append([]float64(nil),
 // --- public constructors ---
 
 // WithSize sets the resize dimensions used during hash computation.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, CLD, EHD, WHash, LBP, HOGHash, RASH, and Zernike.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, CLD, EHD, WHash, LBP, HOGHash, RASH, Zernike, and GIST.
 func WithSize(width, height uint) SizeOption {
 	return sizeOption{width, height}
 }
 
 // WithInterpolation sets the resize interpolation method.
-// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, CLD, EHD, WHash, LBP, HOGHash, PDQ, RASH, and Zernike.
+// Applies to Average, Difference, Median, PHash, BlockMean, MarrHildreth, ColorMoment, CLD, EHD, WHash, LBP, HOGHash, PDQ, RASH, Zernike, and GIST.
 func WithInterpolation(interp Interpolation) InterpolationOption {
 	return interpolationOption{interp}
 }
@@ -382,7 +395,7 @@ func WithLevel(level int) LevelOption {
 
 // WithGridSize sets the number of grid cells used to divide the image for
 // spatial histogram computation.
-// Applies to LBP.
+// Applies to LBP and GIST.
 func WithGridSize(x, y uint) GridSizeOption {
 	return gridSizeOption{x, y}
 }

--- a/options_typecheck_test.go
+++ b/options_typecheck_test.go
@@ -82,3 +82,8 @@ var _ ZernikeOption = WithSize(0, 0)
 var _ ZernikeOption = WithInterpolation(Bilinear)
 var _ ZernikeOption = WithDegree(0)
 var _ ZernikeOption = WithDistance(nil)
+
+var _ GISTOption = WithSize(0, 0)
+var _ GISTOption = WithInterpolation(Bilinear)
+var _ GISTOption = WithGridSize(0, 0)
+var _ GISTOption = WithDistance(nil)

--- a/wiki/Algorithms.md
+++ b/wiki/Algorithms.md
@@ -1,6 +1,6 @@
 # Algorithms
 
-imghash supports 16 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
+imghash supports 17 perceptual hashing algorithms. Most are ported from [OpenCV Contrib](https://github.com/opencv/opencv_contrib) and tested against its implementations.
 
 Every constructor accepts functional options. Call with no arguments for defaults, or pass `With*` options to customize:
 
@@ -151,6 +151,20 @@ Based on [Histograms of Oriented Gradients for Human Detection](https://ieeexplo
 | `WithNumBins(n)` | 9 |
 
 With defaults, output is a 9216-element vector (32x32 cells x 9 bins). `WithSize(32, 32)` produces a 144-element hash (4x4 cells x 9 bins).
+
+## GIST Descriptor Hash
+
+Computes an Oliva-Torralba style holistic descriptor by applying an oriented Gabor filter bank and pooling responses over a spatial grid. Compares using cosine distance.
+
+Based on [Modeling the Shape of the Scene: A Holistic Representation of the Spatial Envelope](https://people.csail.mit.edu/torralba/code/spatialenvelope/).
+
+| Option | Default |
+|--------|---------|
+| `WithSize(w, h)` | 64, 64 |
+| `WithInterpolation(i)` | `Bilinear` |
+| `WithGridSize(x, y)` | 4, 4 |
+
+With defaults, output is a 320-element descriptor (`4x4` cells x `20` filter channels). `WithGridSize(2, 2)` produces an 80-element hash.
 
 ## Radial Variance Hash
 

--- a/wiki/Similarity-Metrics.md
+++ b/wiki/Similarity-Metrics.md
@@ -32,6 +32,7 @@ Default metric per algorithm:
 | RASH | `Binary` | Hamming |
 | ColorMoment | `Float64` | L2 (Euclidean) |
 | Zernike | `Float64` | L2 (Euclidean) |
+| GIST | `Float64` | Cosine |
 | CLD | `UInt8` | L2 (Euclidean) |
 | EHD | `UInt8` | L1 (Manhattan) |
 | LBP | `UInt8` | Chi-Square |


### PR DESCRIPTION
## Summary

Adds a new `GIST` descriptor hasher (Oliva & Torralba style) and integrates it across API, options, tests, and docs.

- Added `NewGIST` and `GIST.Calculate` using a Gabor filter bank with spatial pooling.
- Set `GIST.Compare` default metric to **cosine distance**.
- Kept top-level `imghash.Compare` behavior unchanged for non-binary hashes (**L2** default).
- Wired `GIST` into shared option system:
  - `WithSize`
  - `WithInterpolation`
  - `WithGridSize`
  - `WithDistance`
- Added compile-time option type assertions and distance override coverage for GIST.
- Updated docs/tables in README + wiki for algorithm count and default metrics.

## Related Issue

N/A

## Type of Change

- [x] `feat` (new feature)
- [ ] `fix` (bug fix)
- [x] `docs` (documentation only)
- [x] `test` (tests only)
- [ ] `chore` (maintenance/refactor/tooling)
- [ ] Breaking change

## Validation

```bash
go test ./...
make lint
```

Results:
- `go test ./...` passed
- `make lint` passed

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).

## Breaking Changes

None.
