### PR TITLE
chore: improve OpenSSF score

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: codeql
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "25 14 * * 3"
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - go
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,16 +5,17 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           # Use a PAT so CI workflows trigger on the release PR commits.
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -9,16 +9,17 @@ on:
       - ".github/workflows/sync-wiki.yml"
   workflow_dispatch:
 
-permissions:
-  contents: write
+permissions: {}
 
 jobs:
   sync:
     name: Sync Wiki Pages
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Sync wiki markdown pages
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,17 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   vet:
     name: Go Vet
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
       - name: Run Go Vet
@@ -49,49 +51,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
-      - name: Install golangci-lint
-        run: curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v2.10.1
       - name: Run Linter
-        shell: bash
-        run: |
-          set +e
-          OUTPUT=$(golangci-lint run ./... 2>&1)
-          EXIT_CODE=$?
-          set -e
-
-          {
-            echo "## Lint"
-            echo ""
-            if [ $EXIT_CODE -eq 0 ]; then
-              echo "No lint issues found."
-            else
-              echo "**Issues found:**"
-              echo ""
-              echo '```'
-              echo "$OUTPUT"
-              echo '```'
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          exit $EXIT_CODE
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7.0.1
+        with:
+          version: v2.10.1
+          args: ./...
 
   vulncheck:
     name: Vulnerability Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - name: Run govulncheck
         shell: bash
         run: |
@@ -121,9 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
       - name: Run Tests
@@ -240,7 +222,7 @@ jobs:
 
       - name: Upload Coverage Artifact
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage
           path: coverage.out
@@ -252,15 +234,15 @@ jobs:
     needs: test
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
       - name: Install Goveralls
-        run: go install github.com/mattn/goveralls@latest
+        run: go install github.com/mattn/goveralls@v0.0.12
       - name: Download Coverage Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: coverage
       - name: Publish to Coveralls

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,20 +12,18 @@ linters:
     - revive
     - staticcheck
     - unused
-
-linters-settings:
-  revive:
-    enable-all-rules: true
-    rules:
-      - name: blank-imports
-      - name: dot-imports
-      - name: exported
-        arguments:
-          - "checkPrivateReceivers"
-      - name: redefines-builtin-id
-      - name: unexported-return
-      - name: unreachable-code
-      - name: unused-parameter
+  settings:
+    revive:
+      rules:
+        - name: blank-imports
+        - name: dot-imports
+        - name: exported
+          arguments:
+            - "checkPrivateReceivers"
+        - name: redefines-builtin-id
+        - name: unexported-return
+        - name: unreachable-code
+        - name: unused-parameter
 
 formatters:
   enable:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ a pull request.
 
 | Tool | Minimum version | Install |
 |------|----------------|---------|
-| Go | 1.16+ | [go.dev/dl](https://go.dev/dl/) |
+| Go | 1.25+ | [go.dev/dl](https://go.dev/dl/) |
 | golangci-lint | v2.10.1 | Installed automatically by `make lint` |
 | govulncheck | latest | Installed automatically by `make vulncheck` |
 | GNU Make | any | Pre-installed on most systems |
@@ -71,6 +71,7 @@ must pass.
    - **Go Vet** — `go vet ./...`
    - **Lint** — `golangci-lint run ./...`
    - **Vulnerability Check** — `govulncheck ./...`
+   - **CodeQL** — static application security testing
    - **Test & Coverage** — `go test` with an 80 % minimum coverage threshold
 
 5. A maintainer will review your PR. Please be responsive to feedback — small

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,8 +27,15 @@ You should receive an initial acknowledgement within 72 hours. From there the
 maintainers will work with you to understand the issue, confirm it, and
 coordinate a fix and disclosure timeline.
 
-## Dependency Scanning
+## Automated Security Scanning
 
-This project runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
-in CI on every pull request and push to `main` to catch known vulnerabilities in
-dependencies.
+This project employs several automated tools to catch vulnerabilities early:
+
+- **[govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)** runs
+  in CI on every pull request and push to `main` to catch known vulnerabilities
+  in dependencies.
+- **[CodeQL](https://codeql.github.com/)** performs static application security
+  testing (SAST) on every pull request, push to `main`, and on a weekly schedule.
+- **[Dependabot](https://docs.github.com/en/code-security/dependabot)** monitors
+  Go module dependencies and GitHub Actions for available updates and opens pull
+  requests automatically.

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,87 @@
+package imghash
+
+import (
+	"image"
+	"image/color"
+	"testing"
+)
+
+// imageFromBytes builds a small NRGBA image from fuzz input.
+// Returns nil if data is too short to form a valid image.
+func imageFromBytes(data []byte) image.Image {
+	if len(data) < 4 {
+		return nil
+	}
+	w := int(data[0])%32 + 1
+	h := int(data[1])%32 + 1
+	img := image.NewNRGBA(image.Rect(0, 0, w, h))
+	pixels := data[2:]
+	for y := range h {
+		for x := range w {
+			i := (y*w + x) * 4
+			var r, g, b, a byte
+			if i < len(pixels) {
+				r = pixels[i]
+			}
+			if i+1 < len(pixels) {
+				g = pixels[i+1]
+			}
+			if i+2 < len(pixels) {
+				b = pixels[i+2]
+			}
+			if i+3 < len(pixels) {
+				a = pixels[i+3]
+			}
+			img.SetNRGBA(x, y, color.NRGBA{R: r, G: g, B: b, A: a})
+		}
+	}
+	return img
+}
+
+func FuzzAverageCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewAverage()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzDifferenceCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewDifference()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzPHashCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewPHash()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzMedianCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(t *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewMedian()
+		h.Calculate(img) //nolint:errcheck
+	})
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -40,7 +40,7 @@ func imageFromBytes(data []byte) image.Image {
 
 func FuzzAverageCalculate(f *testing.F) {
 	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		img := imageFromBytes(data)
 		if img == nil {
 			return
@@ -52,7 +52,7 @@ func FuzzAverageCalculate(f *testing.F) {
 
 func FuzzDifferenceCalculate(f *testing.F) {
 	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		img := imageFromBytes(data)
 		if img == nil {
 			return
@@ -64,7 +64,7 @@ func FuzzDifferenceCalculate(f *testing.F) {
 
 func FuzzPHashCalculate(f *testing.F) {
 	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		img := imageFromBytes(data)
 		if img == nil {
 			return
@@ -76,7 +76,7 @@ func FuzzPHashCalculate(f *testing.F) {
 
 func FuzzMedianCalculate(f *testing.F) {
 	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
-	f.Fuzz(func(t *testing.T, data []byte) {
+	f.Fuzz(func(_ *testing.T, data []byte) {
 		img := imageFromBytes(data)
 		if img == nil {
 			return


### PR DESCRIPTION
## Summary

Improve the OpenSSF Scorecard from 4.5/10 by addressing five checks that scored 0:

- **Token-Permissions** — Restrict top-level workflow permissions to read-only; grant write only at job level where needed
- **Pinned-Dependencies** — Pin all GitHub Actions to commit SHAs; pin `govulncheck` and `goveralls` to specific versions; replace `curl | sh` golangci-lint install with `golangci-lint-action`
- **SAST** — Add CodeQL workflow for static application security testing on PRs, pushes, and weekly schedule
- **Fuzzing** — Add native Go fuzz tests for Average, Difference, PHash, and Median hash algorithms
- **Dependency-Update-Tool** — Add Dependabot configuration for Go modules and GitHub Actions

Also updates SECURITY.md and CONTRIBUTING.md to reflect the new tooling.

## Type of Change

- [x] `chore` (maintenance/refactor/tooling)

## Validation

Verified all workflow YAML is syntactically valid and fuzz tests compile against the existing API.

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [ ] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).