### PR TITLE
test: Expand fuzz tests and add them to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,6 +227,68 @@ jobs:
           name: coverage
           path: coverage.out
 
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+      - name: Run Fuzz Tests
+        shell: bash
+        run: |
+          set +e
+          FUZZ_TIME=10s
+          TARGETS=$(grep -o 'func Fuzz[A-Za-z0-9_]*' fuzz_test.go | sed 's/^func //')
+          TOTAL=$(echo "$TARGETS" | wc -l | tr -d ' ')
+          PASSED=0
+          FAILED=0
+          FAILED_TARGETS=""
+
+          for target in $TARGETS; do
+            echo "::group::Fuzzing $target for $FUZZ_TIME"
+            OUTPUT=$(go test -run='^$' -fuzz="^${target}$" -fuzztime="$FUZZ_TIME" 2>&1)
+            EXIT_CODE=$?
+            echo "$OUTPUT"
+            echo "::endgroup::"
+
+            if [ $EXIT_CODE -eq 0 ]; then
+              PASSED=$((PASSED + 1))
+            else
+              FAILED=$((FAILED + 1))
+              FAILED_TARGETS="$FAILED_TARGETS $target"
+            fi
+          done
+
+          {
+            echo "## Fuzz Tests"
+            echo ""
+            if [ "$FAILED" -eq 0 ]; then
+              echo "All fuzz targets passed ($FUZZ_TIME per target)."
+            else
+              echo "**Some fuzz targets failed.**"
+            fi
+            echo ""
+            echo "| Passed | Failed | Total |"
+            echo "|--------|--------|-------|"
+            echo "| $PASSED | $FAILED | $TOTAL |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$FAILED" -gt 0 ]; then
+            {
+              echo ""
+              echo "### Failed Targets"
+              echo ""
+              for target in $FAILED_TARGETS; do
+                echo "- \`$target\`"
+              done
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
   coveralls:
     name: Publish Coverage Report
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ make vet        # Run go vet
 make lint       # Run golangci-lint (installs it if missing)
 make vulncheck  # Run govulncheck (installs it if missing)
 make test       # Run the test suite
+make fuzz       # Run all fuzz targets (default 10s each, override with FUZZ_TIME=30s)
 make coverage   # Run tests with coverage and print a summary
 make all        # fmt + vet + lint + vulncheck + test (recommended before pushing)
 ```
@@ -73,6 +74,7 @@ must pass.
    - **Vulnerability Check** — `govulncheck ./...`
    - **CodeQL** — static application security testing
    - **Test & Coverage** — `go test` with an 80 % minimum coverage threshold
+   - **Fuzz** — every `Fuzz*` target in `fuzz_test.go` is run for 10 s each
 
 5. A maintainer will review your PR. Please be responsive to feedback — small
    follow-up commits are fine; they get squash-merged.
@@ -98,6 +100,9 @@ you agree to uphold these standards.
   functional options (`With*` pattern) over new struct fields.
 - **Test coverage.** New code should be accompanied by tests. The CI enforces an
   80 % minimum coverage threshold — aim to stay above it.
+- **Fuzz tests.** Every hash algorithm has a corresponding `Fuzz*Calculate`
+  target in `fuzz_test.go`. When adding a new algorithm, add a fuzz test
+  following the same pattern.
 
 ## License
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GOLANGCI_LINT_VERSION := v2.10.1
 
-.PHONY: fmt vet test coverage lint lint-install vulncheck vulncheck-install all
+.PHONY: fmt vet test fuzz coverage lint lint-install vulncheck vulncheck-install all
+
+FUZZ_TIME ?= 10s
 
 all: fmt vet lint vulncheck test
 
@@ -12,6 +14,12 @@ vet:
 
 test:
 	go test ./...
+
+fuzz:
+	@grep -o 'func Fuzz[A-Za-z0-9_]*' fuzz_test.go | sed 's/^func //' | while read -r target; do \
+		echo "Fuzzing $$target for $(FUZZ_TIME)..."; \
+		go test -run='^$$' -fuzz="^$${target}$$" -fuzztime=$(FUZZ_TIME) || exit 1; \
+	done
 
 coverage:
 	go test ./... -coverprofile=coverage.out -covermode=atomic

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -85,3 +85,171 @@ func FuzzMedianCalculate(f *testing.F) {
 		h.Calculate(img) //nolint:errcheck
 	})
 }
+
+func FuzzBlockMeanCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewBlockMean()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzMarrHildrethCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewMarrHildreth()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzRadialVarianceCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewRadialVariance()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzColorMomentCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewColorMoment()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzCLDCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewCLD()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzEHDCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewEHD()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzWHashCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewWHash()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzLBPCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewLBP()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzHOGHashCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewHOGHash()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzBoVWCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewBoVW()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzPDQCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewPDQ()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzRASHCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewRASH()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzZernikeCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewZernike()
+		h.Calculate(img) //nolint:errcheck
+	})
+}
+
+func FuzzGISTCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewGIST()
+		h.Calculate(img) //nolint:errcheck
+	})
+}


### PR DESCRIPTION
## Summary

Expand fuzz test coverage from 4 to all 18 hash algorithms and integrate fuzz testing into CI.

**Previously**, only `Average`, `Difference`, `PHash`, and `Median` had fuzz tests. This PR adds fuzz tests for the remaining 14 algorithms: `BlockMean`, `MarrHildreth`, `RadialVariance`, `ColorMoment`, `CLD`, `EHD`, `WHash`, `LBP`, `HOGHash`, `BoVW`, `PDQ`, `RASH`, `Zernike`, and `GIST`.

### Changes

- **`fuzz_test.go`** — Add 14 new `Fuzz*Calculate` functions following the existing pattern (random bytes → NRGBA image → `Calculate()`)
- **`Makefile`** — Add `make fuzz` target that auto-discovers and runs all fuzz targets sequentially (configurable via `FUZZ_TIME`, default 10s per target)
- **`.github/workflows/test.yml`** — Add dedicated `fuzz` CI job that runs all fuzz targets for 10s each, with GitHub step summary reporting pass/fail counts and listing any failing targets

## Type of Change

- [x] `test` (tests only)
- [x] `chore` (maintenance/refactor/tooling)

## Validation

```bash
# All fuzz seed corpora pass as regular tests
go test -run 'Fuzz' -count=1 -v ./...

# Makefile target runs all 18 fuzz targets
make fuzz FUZZ_TIME=1s
```

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).