### PR TITLE
chore: Update badge link for best practices project

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   <a href="https://pkg.go.dev/github.com/ajdnik/imghash/v2"><img src="https://pkg.go.dev/badge/github.com/ajdnik/imghash/v2.svg" alt="Go reference"></a>
   <a href="https://goreportcard.com/report/github.com/ajdnik/imghash/v2"><img src="https://goreportcard.com/badge/github.com/ajdnik/imghash/v2" alt="Go report card"></a>
   <a href="https://github.com/ajdnik/imghash/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-lightgrey.svg" alt="MIT license"></a>
-  <a href="https://www.bestpractices.dev/projects/12605"><img src="https://www.bestpractices.dev/projects/12605/badge"></a>
+  <a href="https://www.bestpractices.dev/projects/12605"><img src="https://www.bestpractices.dev/projects/12605/badge?v=2"></a>
 </p>
 
 ## Documentation


### PR DESCRIPTION
## Summary

Append `?v=2` query param to OpenSSF Best Practices badge URL in README to bust CDN cache and display current badge status.

## Type of Change

- [x] `chore` (maintenance/refactor/tooling)

## Checklist

- [x] I ran relevant checks locally (`make all` recommended).
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the [Code of Conduct](../CODE_OF_CONDUCT.md).