### PR TITLE
feat: Add ColorHash algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ func main() {
 | WHash | `Binary` | Hamming |
 | MarrHildreth | `Binary` | Hamming |
 | BlockMean | `Binary` | Hamming |
+| ColorHash | `Binary` | Hamming |
 | PDQ | `Binary` | Hamming |
 | RASH | `Binary` | Hamming |
 | ColorMoment | `Float64` | L2 (Euclidean) |

--- a/colorhash.go
+++ b/colorhash.go
@@ -169,4 +169,3 @@ func pilHSV(r, g, b uint8) (uint8, uint8) {
 
 	return uint8(hue * 255), uint8(saturation * 255)
 }
-

--- a/colorhash.go
+++ b/colorhash.go
@@ -142,8 +142,8 @@ func pilLuma(r, g, b uint8) uint8 {
 }
 
 func pilHSV(r, g, b uint8) (uint8, uint8) {
-	maxc := max3(r, g, b)
-	minc := min3(r, g, b)
+	maxc := max(r, g, b)
+	minc := min(r, g, b)
 	if maxc == minc {
 		return 0, 0
 	}
@@ -170,22 +170,3 @@ func pilHSV(r, g, b uint8) (uint8, uint8) {
 	return uint8(hue * 255), uint8(saturation * 255)
 }
 
-func max3(a, b, c uint8) uint8 {
-	if b > a {
-		a = b
-	}
-	if c > a {
-		a = c
-	}
-	return a
-}
-
-func min3(a, b, c uint8) uint8 {
-	if b < a {
-		a = b
-	}
-	if c < a {
-		a = c
-	}
-	return a
-}

--- a/colorhash.go
+++ b/colorhash.go
@@ -1,0 +1,191 @@
+package imghash
+
+import (
+	"image"
+	"image/color"
+	"math"
+
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/internal/imgproc"
+	"github.com/ajdnik/imghash/v2/similarity"
+)
+
+const colorHashBins = 14
+
+// ColorHash is compatible with Johannes Buchner's Python imagehash.colorhash.
+// It encodes black, gray, faint-color hue, and bright-color hue fractions into
+// 14 bins, using binBits bits per bin.
+type ColorHash struct {
+	binBits  uint
+	distFunc DistanceFunc
+}
+
+// NewColorHash creates a new ColorHash with the given options.
+// Without options, it uses binbits=3 to match Python imagehash.colorhash.
+func NewColorHash(opts ...ColorHashOption) (ColorHash, error) {
+	ch := ColorHash{binBits: 3}
+	for _, o := range opts {
+		o.applyColorHash(&ch)
+	}
+	if ch.binBits == 0 {
+		return ColorHash{}, ErrInvalidNumBins
+	}
+	return ch, nil
+}
+
+// Calculate returns a ColorHash compatible with Python imagehash.colorhash.
+func (ch ColorHash) Calculate(img image.Image) (hashtype.Hash, error) {
+	if img == nil {
+		return nil, imgproc.ErrImageIsNil
+	}
+
+	bounds := img.Bounds()
+	total := bounds.Dx() * bounds.Dy()
+	if total == 0 {
+		return nil, ErrInvalidSize
+	}
+
+	var black, gray int
+	var colorCount int
+	faintCounts := make([]int, 6)
+	brightCounts := make([]int, 6)
+
+	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			c := color.NRGBAModel.Convert(img.At(x, y)).(color.NRGBA)
+			r8, g8, b8 := c.R, c.G, c.B
+			intensity := pilLuma(r8, g8, b8)
+			h, s := pilHSV(r8, g8, b8)
+
+			if intensity < 256/8 {
+				black++
+				continue
+			}
+			if s < 256/3 {
+				gray++
+				continue
+			}
+
+			colorCount++
+			bin := hueBin(h)
+			if s < 256*2/3 {
+				faintCounts[bin]++
+			} else if s > 256*2/3 {
+				brightCounts[bin]++
+			}
+		}
+	}
+
+	denomColors := colorCount
+	if denomColors < 1 {
+		denomColors = 1
+	}
+	maxValue := 1 << ch.binBits
+	values := make([]int, 0, colorHashBins)
+	values = append(values, colorHashFractionValue(black, total, maxValue))
+	values = append(values, colorHashFractionValue(gray, total, maxValue))
+	for _, count := range faintCounts {
+		values = append(values, colorHashFractionValue(count, denomColors, maxValue))
+	}
+	for _, count := range brightCounts {
+		values = append(values, colorHashFractionValue(count, denomColors, maxValue))
+	}
+
+	hash := hashtype.NewBinary(uint(colorHashBins) * ch.binBits)
+	var pos uint
+	for _, value := range values {
+		for i := uint(0); i < ch.binBits; i++ {
+			divisor := 1 << (ch.binBits - i - 1)
+			modulus := 1 << (ch.binBits - i)
+			if (value/divisor)%modulus > 0 {
+				if err := hash.SetReverse(pos); err != nil {
+					return nil, err
+				}
+			}
+			pos++
+		}
+	}
+	return hash, nil
+}
+
+// Compare computes the Hamming distance between two ColorHash hashes.
+func (ch ColorHash) Compare(h1, h2 hashtype.Hash) (similarity.Distance, error) {
+	if err := validateBinaryCompareInputs(h1, h2); err != nil {
+		return 0, err
+	}
+	if ch.distFunc != nil {
+		return ch.distFunc(h1, h2)
+	}
+	return similarity.Hamming(h1, h2)
+}
+
+func colorHashFractionValue(count, total, maxValue int) int {
+	value := count * maxValue / total
+	if value >= maxValue {
+		return maxValue - 1
+	}
+	return value
+}
+
+func hueBin(h uint8) int {
+	// numpy.histogram(..., bins=numpy.linspace(0, 255, 7)) puts values equal to
+	// an interior edge into the bin on its right, while the final edge is closed.
+	bin := int(math.Floor(float64(h) * 6 / 255))
+	if bin > 5 {
+		return 5
+	}
+	return bin
+}
+
+func pilLuma(r, g, b uint8) uint8 {
+	return uint8((299*int(r) + 587*int(g) + 114*int(b) + 500) / 1000)
+}
+
+func pilHSV(r, g, b uint8) (uint8, uint8) {
+	maxc := max3(r, g, b)
+	minc := min3(r, g, b)
+	if maxc == minc {
+		return 0, 0
+	}
+
+	rc := float64(maxc-r) / float64(maxc-minc)
+	gc := float64(maxc-g) / float64(maxc-minc)
+	bc := float64(maxc-b) / float64(maxc-minc)
+
+	var hue float64
+	switch maxc {
+	case r:
+		hue = bc - gc
+	case g:
+		hue = 2 + rc - bc
+	default:
+		hue = 4 + gc - rc
+	}
+	hue = math.Mod(hue/6, 1)
+	if hue < 0 {
+		hue += 1
+	}
+	saturation := float64(maxc-minc) / float64(maxc)
+
+	return uint8(hue * 255), uint8(saturation * 255)
+}
+
+func max3(a, b, c uint8) uint8 {
+	if b > a {
+		a = b
+	}
+	if c > a {
+		a = c
+	}
+	return a
+}
+
+func min3(a, b, c uint8) uint8 {
+	if b < a {
+		a = b
+	}
+	if c < a {
+		a = c
+	}
+	return a
+}

--- a/colorhash_test.go
+++ b/colorhash_test.go
@@ -1,0 +1,85 @@
+package imghash_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/v2/hashtype"
+	"github.com/ajdnik/imghash/v2/similarity"
+)
+
+var colorHashCalculateTests = []struct {
+	filename string
+	binBits  uint
+	hash     hashtype.Binary
+}{
+	{"assets/lena.jpg", 3, hashtype.Binary{1, 128, 3, 0, 0, 64}},
+	{"assets/baboon.jpg", 3, hashtype.Binary{25, 16, 64, 32, 0, 0}},
+	{"assets/cat.jpg", 3, hashtype.Binary{15, 128, 0, 0, 0, 0}},
+	{"assets/monarch.jpg", 3, hashtype.Binary{3, 128, 1, 0, 0, 0}},
+	{"assets/peppers.jpg", 3, hashtype.Binary{0, 48, 0, 64, 0, 0}},
+	{"assets/tulips.jpg", 3, hashtype.Binary{36, 132, 64, 32, 0, 0}},
+	{"assets/header.png", 3, hashtype.Binary{96, 1, 192, 0, 0, 0}},
+	{"assets/logo.png", 3, hashtype.Binary{224, 0, 64, 0, 96, 0}},
+	{"assets/cat.jpg", 4, hashtype.Binary{7, 240, 0, 0, 0, 0, 0}},
+}
+
+func TestColorHash_Calculate(t *testing.T) {
+	for _, tt := range colorHashCalculateTests {
+		t.Run(fmt.Sprintf("%s binbits=%d", tt.filename, tt.binBits), func(t *testing.T) {
+			hash, err := imghash.NewColorHash(imghash.WithBinBits(tt.binBits))
+			if err != nil {
+				t.Fatalf("failed to create hasher: %v", err)
+			}
+			img, err := imghash.OpenImage(tt.filename)
+			if err != nil {
+				t.Fatalf("failed to open %s: %v", tt.filename, err)
+			}
+			result, err := hash.Calculate(img)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			res := result.(hashtype.Binary)
+			if !res.Equal(tt.hash) {
+				t.Errorf("got %v, want %v", res, tt.hash)
+			}
+		})
+	}
+}
+
+func TestColorHash_Distance(t *testing.T) {
+	hash, err := imghash.NewColorHash()
+	if err != nil {
+		t.Fatalf("failed to create hasher: %v", err)
+	}
+	img1, err := imghash.OpenImage("assets/lena.jpg")
+	if err != nil {
+		t.Fatalf("failed to open first image: %v", err)
+	}
+	img2, err := imghash.OpenImage("assets/cat.jpg")
+	if err != nil {
+		t.Fatalf("failed to open second image: %v", err)
+	}
+	h1, err := hash.Calculate(img1)
+	if err != nil {
+		t.Fatalf("failed to calculate first hash: %v", err)
+	}
+	h2, err := hash.Calculate(img2)
+	if err != nil {
+		t.Fatalf("failed to calculate second hash: %v", err)
+	}
+	dist, err := hash.Compare(h1, h2)
+	if err != nil {
+		t.Fatalf("failed to compute distance: %v", err)
+	}
+	if !dist.Equal(similarity.Distance(6)) {
+		t.Errorf("got %v, want %v", dist, similarity.Distance(6))
+	}
+}
+
+func TestNewColorHash_InvalidBinBits(t *testing.T) {
+	if _, err := imghash.NewColorHash(imghash.WithBinBits(0)); err != imghash.ErrInvalidNumBins {
+		t.Fatalf("got %v, want %v", err, imghash.ErrInvalidNumBins)
+	}
+}

--- a/colorhash_test.go
+++ b/colorhash_test.go
@@ -1,6 +1,7 @@
 package imghash_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -79,7 +80,7 @@ func TestColorHash_Distance(t *testing.T) {
 }
 
 func TestNewColorHash_InvalidBinBits(t *testing.T) {
-	if _, err := imghash.NewColorHash(imghash.WithBinBits(0)); err != imghash.ErrInvalidNumBins {
+	if _, err := imghash.NewColorHash(imghash.WithBinBits(0)); !errors.Is(err, imghash.ErrInvalidNumBins) {
 		t.Fatalf("got %v, want %v", err, imghash.ErrInvalidNumBins)
 	}
 }

--- a/colorhash_test.go
+++ b/colorhash_test.go
@@ -84,3 +84,41 @@ func TestNewColorHash_InvalidBinBits(t *testing.T) {
 		t.Fatalf("got %v, want %v", err, imghash.ErrInvalidNumBins)
 	}
 }
+
+// ExampleColorHash_Calculate demonstrates how to use the ColorHash Calculate() method.
+// It shows the typical workflow: create a ColorHash instance, open an image,
+// compute its color hash, and verify the result.
+func ExampleColorHash_Calculate() {
+	// Create a new ColorHash instance with default settings (binBits=3)
+	hash, err := imghash.NewColorHash()
+	if err != nil {
+		fmt.Printf("failed to create hasher: %v\n", err)
+		return
+	}
+
+	// Load an image from file
+	img, err := imghash.OpenImage("assets/lena.jpg")
+	if err != nil {
+		fmt.Printf("failed to open image: %v\n", err)
+		return
+	}
+
+	// Calculate the color hash
+	result, err := hash.Calculate(img)
+	if err != nil {
+		fmt.Printf("failed to calculate hash: %v\n", err)
+		return
+	}
+
+	// Type assert to Binary to inspect or compare the hash
+	binaryHash, ok := result.(hashtype.Binary)
+	if !ok {
+		fmt.Printf("unexpected hash type\n")
+		return
+	}
+
+	fmt.Printf("Color hash: %v\n", binaryHash)
+
+	// Output:
+	// Color hash: [1 128 3 0 0 64]
+}

--- a/imghash.go
+++ b/imghash.go
@@ -17,7 +17,7 @@ type DistanceFunc func(hashtype.Hash, hashtype.Hash) (similarity.Distance, error
 // Hasher computes a perceptual hash from an image.
 // It is implemented by all hash algorithms in this package:
 // Average, Difference, PHash, Median, BlockMean, MarrHildreth,
-// RadialVariance, ColorMoment, CLD, EHD, WHash, LBP, HOGHash, BoVW, PDQ, RASH, Zernike, and GIST.
+// RadialVariance, ColorMoment, ColorHash, CLD, EHD, WHash, LBP, HOGHash, BoVW, PDQ, RASH, Zernike, and GIST.
 type Hasher interface {
 	Calculate(image.Image) (hashtype.Hash, error)
 }
@@ -46,6 +46,7 @@ var (
 	_ HasherComparer = MarrHildreth{}
 	_ HasherComparer = RadialVariance{}
 	_ HasherComparer = ColorMoment{}
+	_ HasherComparer = ColorHash{}
 	_ HasherComparer = CLD{}
 	_ HasherComparer = EHD{}
 	_ HasherComparer = WHash{}

--- a/options.go
+++ b/options.go
@@ -42,6 +42,9 @@ type RadialVarianceOption interface{ applyRadialVariance(*RadialVariance) }
 // ColorMomentOption configures the ColorMoment hash algorithm.
 type ColorMomentOption interface{ applyColorMoment(*ColorMoment) }
 
+// ColorHashOption configures the ColorHash algorithm.
+type ColorHashOption interface{ applyColorHash(*ColorHash) }
+
 // CLDOption configures the CLD hash algorithm.
 type CLDOption interface{ applyCLD(*CLD) }
 
@@ -85,6 +88,7 @@ type DistanceOption interface {
 	MarrHildrethOption
 	RadialVarianceOption
 	ColorMomentOption
+	ColorHashOption
 	CLDOption
 	EHDOption
 	WHashOption
@@ -107,6 +111,7 @@ func (o distanceOption) applyBlockMean(b *BlockMean)           { b.distFunc = o.
 func (o distanceOption) applyMarrHildreth(m *MarrHildreth)     { m.distFunc = o.fn }
 func (o distanceOption) applyRadialVariance(r *RadialVariance) { r.distFunc = o.fn }
 func (o distanceOption) applyColorMoment(c *ColorMoment)       { c.distFunc = o.fn }
+func (o distanceOption) applyColorHash(c *ColorHash)           { c.distFunc = o.fn }
 func (o distanceOption) applyCLD(c *CLD)                       { c.distFunc = o.fn }
 func (o distanceOption) applyEHD(e *EHD)                       { e.distFunc = o.fn }
 func (o distanceOption) applyWHash(w *WHash)                   { w.distFunc = o.fn }
@@ -139,6 +144,15 @@ type SizeOption interface {
 	GISTOption
 	BoVWOption
 }
+
+// BinBitsOption sets the number of bits used to encode each ColorHash bin.
+type BinBitsOption interface {
+	ColorHashOption
+}
+
+type binBitsOption struct{ bits uint }
+
+func (o binBitsOption) applyColorHash(c *ColorHash) { c.binBits = o.bits }
 
 type sizeOption struct{ width, height uint }
 
@@ -528,6 +542,12 @@ func WithMinHashSize(size uint) MinHashSizeOption {
 // Applies to BoVW.
 func WithSimHashBits(bits uint) SimHashBitsOption {
 	return simHashBitsOption{bits: bits}
+}
+
+// WithBinBits sets the number of bits used to encode each ColorHash bin.
+// Applies to ColorHash.
+func WithBinBits(bits uint) BinBitsOption {
+	return binBitsOption{bits: bits}
 }
 
 // WithDistance overrides the default distance function used by Compare.

--- a/wiki/Algorithms.md
+++ b/wiki/Algorithms.md
@@ -129,6 +129,54 @@ Block mean methods: `Direct`, `Overlap`, `Rotation`, `RotationOverlap`.
 
 `Rotation` and `RotationOverlap` compute and concatenate hashes for 24 rotations (0 to 345 degrees in 15-degree steps), so the result is 24x larger than non-rotational mode.
 
+## ColorHash
+
+Encodes black, gray, faint-color hue, and bright-color hue fractions into 14 bins. Compares using Hamming distance. Compatible with [Johannes Buchner's Python imagehash.colorhash](https://github.com/JohannesBuchner/imagehash).
+
+The algorithm categorizes each pixel into one of several categories:
+- **Black**: intensity < 32 (256/8)
+- **Gray**: saturation < 85 (256/3)
+- **Faint color**: saturation between 85 and 170 with hue divided into 6 bins
+- **Bright color**: saturation > 170 with hue divided into 6 bins
+
+The histogram is encoded into 14 bins: 1 for black pixels, 1 for gray pixels, 6 for faint colors, 6 for bright colors. Each bin uses `binBits` bits (default 3), producing a hash of length 14 × binBits bits (default 42 bits).
+
+| Option | Default |
+|--------|---------|
+| `WithBinBits(n)` | 3 |
+
+Example usage:
+
+```go
+package main
+
+import (
+  "fmt"
+
+  "github.com/ajdnik/imghash/v2"
+)
+
+func main() {
+  // Default color hash (binBits=3)
+  hash, err := imghash.NewColorHash()
+  if err != nil {
+    panic(err)
+  }
+
+  img, err := imghash.OpenImage("image.jpg")
+  if err != nil {
+    panic(err)
+  }
+
+  h, err := hash.Calculate(img)
+  if err != nil {
+    panic(err)
+  }
+
+  fmt.Printf("Color hash: %v\n", h)
+}
+```
+
 ## Local Binary Pattern (LBP) Hash
 
 Computes LBP codes and builds normalized histograms into a `uint8` vector. Compares using chi-square distance.


### PR DESCRIPTION
## Summary
  - Add ColorHash perceptual hashing algorithm, ported from [Johannes Buchner's Python imagehash.colorhash](https://github.com/JohannesBuchner/imagehash)
  - Encodes pixel color distribution (black/gray/faint-hue/bright-hue fractions) into 14 bins with configurable `binBits`
  - Produces binary hash, compared via Hamming distance

  ## Notes
  - Configurable via `WithBinBits(n)` option (default 3, producing 42-bit hash)
  - Implements `HasherComparer` interface consistent with existing algorithms