### PR TITLE
test: add fuzz test for ColorHash

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -253,3 +253,15 @@ func FuzzGISTCalculate(f *testing.F) {
 		h.Calculate(img) //nolint:errcheck
 	})
 }
+
+func FuzzColorHashCalculate(f *testing.F) {
+	f.Add([]byte{8, 8, 0xFF, 0xAA, 0x55, 0x00})
+	f.Fuzz(func(_ *testing.T, data []byte) {
+		img := imageFromBytes(data)
+		if img == nil {
+			return
+		}
+		h, _ := NewColorHash()
+		h.Calculate(img) //nolint:errcheck
+	})
+}

--- a/wiki/Algorithms.md
+++ b/wiki/Algorithms.md
@@ -145,38 +145,6 @@ The histogram is encoded into 14 bins: 1 for black pixels, 1 for gray pixels, 6 
 |--------|---------|
 | `WithBinBits(n)` | 3 |
 
-Example usage:
-
-```go
-package main
-
-import (
-  "fmt"
-
-  "github.com/ajdnik/imghash/v2"
-)
-
-func main() {
-  // Default color hash (binBits=3)
-  hash, err := imghash.NewColorHash()
-  if err != nil {
-    panic(err)
-  }
-
-  img, err := imghash.OpenImage("image.jpg")
-  if err != nil {
-    panic(err)
-  }
-
-  h, err := hash.Calculate(img)
-  if err != nil {
-    panic(err)
-  }
-
-  fmt.Printf("Color hash: %v\n", h)
-}
-```
-
 ## Local Binary Pattern (LBP) Hash
 
 Computes LBP codes and builds normalized histograms into a `uint8` vector. Compares using chi-square distance.


### PR DESCRIPTION
## Summary

This PR adds a fuzz test for the recently introduced `ColorHash` algorithm to ensure its robustness against edge-case image data. It also removes a redundant code example from the wiki documentation to keep it concise.

## Related Issue

N/A

## Type of Change

- [x] test (tests only)
- [x] docs (documentation only)

## Validation

Ran the new fuzz test locally for 10 seconds without failures:
```bash
go test -run=^$ -fuzz=FuzzColorHashCalculate -fuzztime=10s .
```

## Checklist

- [x] I ran relevant checks locally.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the Code of Conduct /CODE_OF_CONDUCT.md.

## Breaking Changes

None.