### PR TITLE
chore: compute and upload ossf scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 6 * * 0"
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Run OSSF Scorecard
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca94b1 # v2.4.2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Upload Results
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Added a new GitHub Actions workflow to run the [OSSF Scorecard](https://github.com/ossf/scorecard-action) analysis. This tool evaluates the project for security best practices and uploads the results to GitHub's code scanning dashboard.

## Related Issue

None.

## Type of Change

- [ ] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation only)
- [ ] test (tests only)
- [x] chore (maintenance/refactor/tooling)
- [ ] Breaking change

## Validation

The workflow is based on the standard OSSF Scorecard template. It is configured to run on pushes to main, branch protection rule changes, and on a weekly schedule.

## Checklist

- [x] I ran relevant checks locally (make all recommended).
- [ ] I added or updated tests for behavior changes.
- [ ] I updated docs/examples when needed.
- [x] I used a Conventional Commit message format.
- [x] I confirmed no secrets or private data are included.
- [x] I have read and followed the Code of Conduct /CODE_OF_CONDUCT.md.

## Breaking Changes

None.