### PR TITLE
docs(ci): make wiki-sync empty-dir cleanup compatible with -delete

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -47,7 +47,7 @@ jobs:
           # Mirror every .md file (including subdirectories such as algorithms/,
           # api/, concepts/, guides/) and prune anything left behind.
           find wiki-repo -mindepth 1 -path wiki-repo/.git -prune -o -type f -name '*.md' -print -exec rm -f {} +
-          find wiki-repo -mindepth 1 -path wiki-repo/.git -prune -o -type d -empty -print -delete
+          find wiki-repo -mindepth 1 -not -path 'wiki-repo/.git' -not -path 'wiki-repo/.git/*' -type d -empty -delete
           (cd wiki && find . -type f -name '*.md' -print0 | tar --null -cf - -T -) | tar -xf - -C wiki-repo
 
           cd wiki-repo


### PR DESCRIPTION
## Summary
- `sync-wiki.yml` failed with `find: The -delete action automatically turns on -depth, but -prune does nothing when -depth is in effect.`
- Root cause: `-delete` implies `-depth`, which disables `-prune`, so `wiki-repo/.git` was no longer excluded and the find aborted.
- Replaced `-prune` with `-not -path 'wiki-repo/.git' -not -path 'wiki-repo/.git/*'` filters so `.git` stays excluded under `-delete`.

## Test plan
- [ ] Re-run `sync-wiki` workflow (push to `wiki/**` or `workflow_dispatch`) and confirm no `find` error.
- [ ] Confirm wiki repo still has `.git` intact after the run.
- [ ] Confirm empty directories outside `.git` are removed.