### PR TITLE
fix(dinoweights): move module out of /v2/ namespace

### DIFF
--- a/dinoweights/dinoweights.go
+++ b/dinoweights/dinoweights.go
@@ -1,5 +1,5 @@
 // Package dinoweights ships the default model weights used by
-// github.com/ajdnik/imghash/v2/dinohash. The blob is the fused 96-bit ONNX
+// github.com/ajdnik/imghash/v2. The blob is the fused 96-bit ONNX
 // checkpoint dinov2_vits14_reg_96bit.onnx published by
 // https://github.com/proteus-photos/dinohash-perceptual-hash, converted to
 // safetensors fp32. fp32 is preserved on purpose so the embedded values are
@@ -13,11 +13,11 @@
 // Usage:
 //
 //	import (
-//	    "github.com/ajdnik/imghash/v2/dinohash"
-//	    "github.com/ajdnik/imghash/v2/dinoweights"
+//	    "github.com/ajdnik/imghash/v2"
+//	    "github.com/ajdnik/imghash/dinoweights"
 //	)
 //
-//	d, err := dinohash.NewDINOHash(dinohash.WithSafetensorsBlob(dinoweights.Blob))
+//	d, err := imghash.NewDINOHash(imghash.WithSafetensorsBlob(dinoweights.Blob))
 package dinoweights
 
 import _ "embed"

--- a/dinoweights/go.mod
+++ b/dinoweights/go.mod
@@ -1,3 +1,3 @@
-module github.com/ajdnik/imghash/v2/dinoweights
+module github.com/ajdnik/imghash/dinoweights
 
 go 1.25.0

--- a/wiki/algorithms/dinohash.md
+++ b/wiki/algorithms/dinohash.md
@@ -28,12 +28,12 @@ Avoid DINOHash when:
 
 ## Weights
 
-This package ships no model weights. The canonical blob lives in a sibling module `github.com/ajdnik/imghash/v2/dinoweights`:
+This package ships no model weights. The canonical blob lives in a sibling module `github.com/ajdnik/imghash/dinoweights`:
 
 ```go
 import (
   "github.com/ajdnik/imghash/v2"
-  "github.com/ajdnik/imghash/v2/dinoweights"
+  "github.com/ajdnik/imghash/dinoweights"
 )
 
 d, err := imghash.NewDINOHash(imghash.WithSafetensorsBlob(dinoweights.Blob))
@@ -67,7 +67,7 @@ import (
   "fmt"
 
   "github.com/ajdnik/imghash/v2"
-  "github.com/ajdnik/imghash/v2/dinoweights"
+  "github.com/ajdnik/imghash/dinoweights"
 )
 
 func main() {

--- a/wiki/guides/choosing-algorithm.md
+++ b/wiki/guides/choosing-algorithm.md
@@ -297,7 +297,7 @@ When inputs may be deliberately edited to defeat classical hashes (e.g. heavy cr
 ```go
 import (
     "github.com/ajdnik/imghash/v2"
-    "github.com/ajdnik/imghash/v2/dinoweights"
+    "github.com/ajdnik/imghash/dinoweights"
 )
 
 pdq, _ := imghash.NewPDQ()

--- a/wiki/guides/examples.md
+++ b/wiki/guides/examples.md
@@ -525,7 +525,7 @@ package main
 import (
     "fmt"
     "github.com/ajdnik/imghash/v2"
-    "github.com/ajdnik/imghash/v2/dinoweights"
+    "github.com/ajdnik/imghash/dinoweights"
 )
 
 type TwoStageModerator struct {

--- a/wiki/installation.md
+++ b/wiki/installation.md
@@ -128,7 +128,7 @@ DINOHash ships its model weights in a sibling Go module so importers of `imghash
 ### Install dinoweights
 
 ```bash
-go get -u github.com/ajdnik/imghash/v2/dinoweights
+go get -u github.com/ajdnik/imghash/dinoweights
 ```
 
 This adds the module to your `go.mod` and pulls down the embedded safetensors blob (~85 MB) once.
@@ -138,7 +138,7 @@ This adds the module to your `go.mod` and pulls down the embedded safetensors bl
 ```go
 import (
     "github.com/ajdnik/imghash/v2"
-    "github.com/ajdnik/imghash/v2/dinoweights"
+    "github.com/ajdnik/imghash/dinoweights"
 )
 
 d, err := imghash.NewDINOHash(imghash.WithSafetensorsBlob(dinoweights.Blob))
@@ -223,7 +223,7 @@ If you also use DINOHash, your `go.mod` will include the `dinoweights` module:
 ```go
 require (
     github.com/ajdnik/imghash/v2 v2.x.x
-    github.com/ajdnik/imghash/v2/dinoweights v1.x.x
+    github.com/ajdnik/imghash/dinoweights v1.x.x
     golang.org/x/image v0.41.0 // indirect
     gonum.org/v1/gonum v0.17.0 // indirect
 )

--- a/wiki/quickstart.md
+++ b/wiki/quickstart.md
@@ -346,7 +346,7 @@ func main() {
 DINOHash requires the sibling `dinoweights` module for its embedded DINOv2 ViT-S/14+reg model weights (~85 MB):
 
 ```bash
-go get -u github.com/ajdnik/imghash/v2/dinoweights
+go get -u github.com/ajdnik/imghash/dinoweights
 ```
 
 ```go
@@ -355,7 +355,7 @@ package main
 import (
     "fmt"
     "github.com/ajdnik/imghash/v2"
-    "github.com/ajdnik/imghash/v2/dinoweights"
+    "github.com/ajdnik/imghash/dinoweights"
 )
 
 func main() {


### PR DESCRIPTION
## Summary
- Rename `dinoweights` module path from `github.com/ajdnik/imghash/v2/dinoweights` to `github.com/ajdnik/imghash/dinoweights` so the release-please tag `dinoweights/vX.Y.Z` resolves under Go's submodule tagging convention.
- Fix stale doc comments in `dinoweights.go` that referenced a nonexistent `v2/dinohash` subpackage (real API is in `package imghash`).
- Update wiki import paths to the new module path.

## Why
Tag `dinoweights/v1.1.0` exists on remote, but the prior module path embedded the parent's `/v2/` mid-path. Go treats the subdir prefix as `v2/dinoweights` and tries to fetch tag `v2/dinoweights/v1.1.0`, which doesn't exist. Dropping `/v2/` from the submodule path aligns the expected tag prefix with what release-please actually produces.

## Follow-up
This PR scopes to the dinoweights module + docs only. A separate PR will update the parent module's `go.mod` require + `replace` directive once a new `dinoweights/vX.Y.Z` tag is cut against the renamed module.

## Test plan
- [x] `go build ./...` and `go vet ./...` in `dinoweights/` pass
- [x] `go build ./...` and `go test -run "^$" ./...` at repo root pass (replace directive bridges old require path to local dir)
- [x] No `v2/dinoweights` or `v2/dinohash` references remain in `wiki/` or `dinoweights/`