### PR TITLE
fix(dinoweights): drop from main module require to stop 85MB consumer download

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -152,7 +152,7 @@ jobs:
           TEST_EXIT=$?
           set -e
 
-          MODULE=$(go list -m)
+          MODULE=$(GOWORK=off go list -m)
           grep '^\{' test-output.json > test-results.json 2>/dev/null || true
 
           TESTS_PASSED=$(jq -s '[.[] | select(.Test != null and .Action == "pass")] | length' test-results.json 2>/dev/null || echo 0)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,16 @@ permissions: read-all
 
 jobs:
   vet:
-    name: Go Vet
+    name: Go Vet (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: .
+            name: main
+          - module: ./dinoweights
+            name: dinoweights
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -24,6 +32,7 @@ jobs:
           go-version: "1.25"
       - name: Run Go Vet
         shell: bash
+        working-directory: ${{ matrix.module }}
         run: |
           set +e
           OUTPUT=$(go vet ./... 2>&1)
@@ -31,7 +40,7 @@ jobs:
           set -e
 
           {
-            echo "## Go Vet"
+            echo "## Go Vet (${{ matrix.name }})"
             echo ""
             if [ $EXIT_CODE -eq 0 ]; then
               echo "All packages pass vet checks."
@@ -47,8 +56,16 @@ jobs:
           exit $EXIT_CODE
 
   lint:
-    name: Lint
+    name: Lint (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: .
+            name: main
+          - module: ./dinoweights
+            name: dinoweights
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -61,10 +78,19 @@ jobs:
         with:
           version: v2.10.1
           args: ./...
+          working-directory: ${{ matrix.module }}
 
   vulncheck:
-    name: Vulnerability Check
+    name: Vulnerability Check (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: .
+            name: main
+          - module: ./dinoweights
+            name: dinoweights
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -76,6 +102,7 @@ jobs:
         run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - name: Run govulncheck
         shell: bash
+        working-directory: ${{ matrix.module }}
         run: |
           set +e
           OUTPUT=$(govulncheck ./... 2>&1)
@@ -83,7 +110,7 @@ jobs:
           set -e
 
           {
-            echo "## Vulnerability Check"
+            echo "## Vulnerability Check (${{ matrix.name }})"
             echo ""
             if [ $EXIT_CODE -eq 0 ]; then
               echo "No known vulnerabilities found."
@@ -99,8 +126,16 @@ jobs:
           exit $EXIT_CODE
 
   test:
-    name: Test & Coverage
+    name: Test (${{ matrix.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - module: .
+            name: main
+          - module: ./dinoweights
+            name: dinoweights
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -110,6 +145,7 @@ jobs:
           go-version: "1.25"
       - name: Run Tests
         shell: bash
+        working-directory: ${{ matrix.module }}
         run: |
           set +e
           go test -covermode=atomic -coverprofile=coverage.out -coverpkg=./... -json ./... > test-output.json 2>&1
@@ -124,7 +160,7 @@ jobs:
           TESTS_SKIPPED=$(jq -s '[.[] | select(.Test != null and .Action == "skip")] | length' test-results.json 2>/dev/null || echo 0)
 
           {
-            echo "## Test Results"
+            echo "## Test Results (${{ matrix.name }})"
             echo ""
             if [ "$TEST_EXIT" -eq 0 ]; then
               echo "All tests passed."
@@ -180,11 +216,39 @@ jobs:
 
           exit $TEST_EXIT
 
-      - name: Coverage Report
+      - name: Upload Per-Module Coverage
         if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-${{ matrix.name }}
+          path: ${{ matrix.module }}/coverage.out
+          if-no-files-found: ignore
+
+  coverage:
+    name: Coverage Report
+    runs-on: ubuntu-latest
+    needs: test
+    if: success() || failure()
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: "1.25"
+      - name: Install gocovmerge
+        run: go install github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad
+      - name: Download Coverage Artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+      - name: Merge Coverage
         shell: bash
         run: |
-          if [ ! -f coverage.out ]; then
+          shopt -s nullglob
+          PROFILES=(coverage-artifacts/*/coverage.out)
+          if [ ${#PROFILES[@]} -eq 0 ]; then
             {
               echo "## Coverage"
               echo ""
@@ -192,6 +256,7 @@ jobs:
             } >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          gocovmerge "${PROFILES[@]}" > coverage.out
 
           COVER_OUTPUT=$(go tool cover -func=coverage.out)
           COVERAGE=$(echo "$COVER_OUTPUT" | grep "^total:" | awk '{print $NF}' | tr -d '%')
@@ -220,7 +285,7 @@ jobs:
             exit 1
           fi
 
-      - name: Upload Coverage Artifact
+      - name: Upload Merged Coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/main' && success()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -293,7 +358,7 @@ jobs:
     name: Publish Coverage Report
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: test
+    needs: coverage
     steps:
       - name: Checkout Code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/dinohash.go
+++ b/dinohash.go
@@ -19,7 +19,7 @@ type Tensor = dinov2.Tensor
 
 // WeightsProvider supplies the named float32 tensors that constitute a
 // DINOHash model. The canonical source is the byte slice in the sibling
-// module github.com/ajdnik/imghash/v2/dinoweights, supplied via
+// module github.com/ajdnik/imghash/dinoweights, supplied via
 // WithSafetensorsBlob. Implement this interface to load weights from disk,
 // network, or a custom format.
 type WeightsProvider interface {
@@ -65,11 +65,11 @@ func (s safetensorsProvider) Tensors() (map[string]Tensor, error) {
 //
 // This package ships no model weights. Supply them via WithSafetensorsBlob
 // (most convenient) or WithDINOWeights (for custom providers). The default
-// blob lives in the sibling module github.com/ajdnik/imghash/v2/dinoweights:
+// blob lives in the sibling module github.com/ajdnik/imghash/dinoweights:
 //
 //	import (
 //	    "github.com/ajdnik/imghash/v2"
-//	    "github.com/ajdnik/imghash/v2/dinoweights"
+//	    "github.com/ajdnik/imghash/dinoweights"
 //	)
 //
 //	d, err := imghash.NewDINOHash(imghash.WithSafetensorsBlob(dinoweights.Blob))

--- a/dinoweights/dinohash_integration_test.go
+++ b/dinoweights/dinohash_integration_test.go
@@ -1,12 +1,12 @@
-package imghash_test
+package dinoweights_test
 
 import (
 	"encoding/hex"
 	"math/bits"
 	"testing"
 
-	"github.com/ajdnik/imghash/v2"
-	"github.com/ajdnik/imghash/v2/dinoweights"
+	imghash "github.com/ajdnik/imghash/v2"
+	"github.com/ajdnik/imghash/dinoweights"
 	"github.com/ajdnik/imghash/v2/hashtype"
 )
 
@@ -25,12 +25,12 @@ import (
 // allows up to 1 bit of distance against the Python reference. Add a
 // PIL-replica resize and tighten this to zero once parity is required.
 var pythonONNXRef = map[string]string{
-	"assets/lena.jpg":    "4c3b42ddaec814d3734a9b4f",
-	"assets/baboon.jpg":  "e14526f50f4e2f0fce94a7ef",
-	"assets/cat.jpg":     "cc5328a6e80a178637ee4314",
-	"assets/monarch.jpg": "cc2c35035351b8e5a1023d35",
-	"assets/peppers.jpg": "fc6f91748c81c07d7ca370d6",
-	"assets/tulips.jpg":  "ec2cba311f4d21a2cd334df6",
+	"../assets/lena.jpg":    "4c3b42ddaec814d3734a9b4f",
+	"../assets/baboon.jpg":  "e14526f50f4e2f0fce94a7ef",
+	"../assets/cat.jpg":     "cc5328a6e80a178637ee4314",
+	"../assets/monarch.jpg": "cc2c35035351b8e5a1023d35",
+	"../assets/peppers.jpg": "fc6f91748c81c07d7ca370d6",
+	"../assets/tulips.jpg":  "ec2cba311f4d21a2cd334df6",
 }
 
 func TestDINOHash_Calculate_AgainstPythonONNX(t *testing.T) {
@@ -102,7 +102,7 @@ func TestDINOWeightsBlob_Parseable(t *testing.T) {
 }
 
 func ExampleDINOHash_Calculate() {
-	img, err := imghash.OpenImage("assets/cat.jpg")
+	img, err := imghash.OpenImage("../assets/cat.jpg")
 	if err != nil {
 		panic(err)
 	}

--- a/dinoweights/dinohash_integration_test.go
+++ b/dinoweights/dinohash_integration_test.go
@@ -5,8 +5,8 @@ import (
 	"math/bits"
 	"testing"
 
-	imghash "github.com/ajdnik/imghash/v2"
 	"github.com/ajdnik/imghash/dinoweights"
+	"github.com/ajdnik/imghash/v2"
 	"github.com/ajdnik/imghash/v2/hashtype"
 )
 

--- a/dinoweights/go.mod
+++ b/dinoweights/go.mod
@@ -1,3 +1,10 @@
 module github.com/ajdnik/imghash/dinoweights
 
 go 1.25.0
+
+require github.com/ajdnik/imghash/v2 v2.5.1
+
+require (
+	golang.org/x/image v0.41.0 // indirect
+	gonum.org/v1/gonum v0.17.0 // indirect
+)

--- a/dinoweights/go.sum
+++ b/dinoweights/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/image v0.41.0 h1:8wS72eGJMJaBxK6okTzd4WaXumUlTVlb753MlsSvTCo=
+golang.org/x/image v0.41.0/go.mod h1:uIc348UZMSvS5Z65CVZ7iDPaNobNFEPeJ4kbqTOszmA=
+gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
+gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,6 @@ module github.com/ajdnik/imghash/v2
 go 1.25.0
 
 require (
-	github.com/ajdnik/imghash/v2/dinoweights v0.0.0
 	golang.org/x/image v0.41.0
 	gonum.org/v1/gonum v0.17.0
 )
-
-replace github.com/ajdnik/imghash/v2/dinoweights => ./dinoweights

--- a/go.work
+++ b/go.work
@@ -1,0 +1,6 @@
+go 1.25.0
+
+use (
+	.
+	./dinoweights
+)

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,0 +1,1 @@
+github.com/ajdnik/imghash/v2 v2.5.1/go.mod h1:/zmXHvfAr41U0hDucJVbRVhW01EGV0kbymFbrKHnNLI=

--- a/options.go
+++ b/options.go
@@ -586,7 +586,7 @@ func (o dinoSafetensorsOption) applyDINOHash(d *DINOHash) {
 
 // WithSafetensorsBlob configures DINOHash to parse a safetensors fp32 blob
 // supplied as a raw byte slice. The canonical blob is published in the
-// sibling module github.com/ajdnik/imghash/v2/dinoweights as
+// sibling module github.com/ajdnik/imghash/dinoweights as
 // dinoweights.Blob, but any safetensors blob with the expected tensor names
 // and shapes works.
 //


### PR DESCRIPTION
## Summary

- Remove `github.com/ajdnik/imghash/dinoweights` from main module's `require` block. Consumers running `go get github.com/ajdnik/imghash/v2` no longer pull the 85MB weights blob into their module cache.
- Move `dinohash_integration_test.go` from main module to `dinoweights/`. Production code never imported `dinoweights` — only the integration test did — so the test now lives next to the blob it validates.
- Wire the repo as a two-module workspace via `go.work` so contributors get cross-module resolution without local `replace` directives.
- Update CI: vet/lint/vulncheck/test now matrix over `[main, dinoweights]`; a new `coverage` job merges per-module profiles with `gocovmerge` and enforces the 80% threshold against the merged result; `coveralls` consumes the merged profile.

## Test plan

- [ ] CI green on this branch (vet, lint, vulncheck, test, fuzz, coverage matrix all pass)
- [ ] Coverage threshold (80%) still satisfied by merged profile
- [ ] `go get github.com/ajdnik/imghash/v2` in a fresh module does not pull `dinoweights` (verify module cache size or `go mod graph`)
- [ ] Integration test still runs from `dinoweights/` (`cd dinoweights && go test ./...`)