### PR TITLE
ci: retry fuzz targets on coordinator deadline flake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,11 +313,29 @@ jobs:
           FAILED=0
           FAILED_TARGETS=""
 
+          # The Go fuzzing coordinator has a race between the -fuzztime deadline
+          # firing and its worker context being cancelled, which surfaces as a
+          # bare "context deadline exceeded" failure with no crasher recorded.
+          # Retry those; a real crash always writes a failing input to testdata.
+          MAX_ATTEMPTS=3
+
           for target in $TARGETS; do
             echo "::group::Fuzzing $target for $FUZZ_TIME"
-            OUTPUT=$(go test -run='^$' -fuzz="^${target}$" -fuzztime="$FUZZ_TIME" 2>&1)
-            EXIT_CODE=$?
-            echo "$OUTPUT"
+            for attempt in $(seq 1 $MAX_ATTEMPTS); do
+              OUTPUT=$(go test -run='^$' -fuzz="^${target}$" -fuzztime="$FUZZ_TIME" 2>&1)
+              EXIT_CODE=$?
+              echo "$OUTPUT"
+              if [ $EXIT_CODE -eq 0 ]; then
+                break
+              fi
+              if echo "$OUTPUT" | grep -q 'Failing input written to'; then
+                break
+              fi
+              if ! echo "$OUTPUT" | grep -q 'context deadline exceeded'; then
+                break
+              fi
+              echo "Fuzzing infrastructure flake (attempt $attempt/$MAX_ATTEMPTS), retrying..."
+            done
             echo "::endgroup::"
 
             if [ $EXIT_CODE -eq 0 ]; then

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,22 @@ vet:
 test:
 	go test ./...
 
+# Retries bare "context deadline exceeded" failures: those come from a race in
+# the Go fuzzing coordinator at the -fuzztime deadline, not from the target.
+# A real crash always writes a failing input to testdata, so it is never retried.
 fuzz:
 	@grep -o 'func Fuzz[A-Za-z0-9_]*' fuzz_test.go | sed 's/^func //' | while read -r target; do \
 		echo "Fuzzing $$target for $(FUZZ_TIME)..."; \
-		go test -run='^$$' -fuzz="^$${target}$$" -fuzztime=$(FUZZ_TIME) || exit 1; \
+		for attempt in 1 2 3; do \
+			out=$$(go test -run='^$$' -fuzz="^$${target}$$" -fuzztime=$(FUZZ_TIME) 2>&1); \
+			code=$$?; \
+			echo "$$out"; \
+			[ $$code -eq 0 ] && break; \
+			echo "$$out" | grep -q 'Failing input written to' && exit 1; \
+			echo "$$out" | grep -q 'context deadline exceeded' || exit 1; \
+			echo "Fuzzing flake (attempt $$attempt/3), retrying..."; \
+			[ $$attempt -eq 3 ] && exit 1; \
+		done; \
 	done
 
 coverage:


### PR DESCRIPTION
Fuzz jobs intermittently fail with:

```
--- FAIL: FuzzColorHashCalculate (11.00s)
    context deadline exceeded
FAIL
```

(e.g. https://github.com/ajdnik/imghash/actions/runs/32336276879/job/96326372196)

## Root cause

Not the fuzz targets — a race inside Go's fuzzing coordinator.

In `internal/fuzz/fuzz.go`, `CoordinateFuzzing` builds `ctx = WithTimeout(ctx, fuzztime)` and then `fuzzCtx = WithCancel(ctx)`. The main loop reacts to the deadline with `stop(ctx.Err())`, and `stop` only suppresses the error when `err == fuzzCtx.Err()`.

`context.cancelCtx.cancel` closes its own done channel *before* propagating cancellation to its children. So the coordinator goroutine can wake on the parent's closed channel and read `ctx.Err() == DeadlineExceeded` while `fuzzCtx.Err()` is still `nil`. The comparison misses, `fuzzErr` is set, and the run fails even though nothing crashed.

The window is microseconds wide, which is why it is rare and shows up under load on multi-core runners. It leaves the signature seen above: failure just past the `-fuzztime` budget, no crasher message, no entry written to `testdata/fuzz`.

## Change

Retry a failing target up to three times, but only when the output contains `context deadline exceeded` and does *not* contain `Failing input written to`. A genuine crash always writes a corpus entry first, so real failures are never retried or masked.

Same guard added to `make fuzz` for local parity.

## Verification

- `bash -n` on the extracted workflow script passes
- `FUZZ_TIME=2s make fuzz` runs all targets green